### PR TITLE
feat: Optimize scheduler path for Folia and improve task metadata

### DIFF
--- a/FoliaPhantom/src/main/java/summer/foliaPhantom/FoliaPhantom.java
+++ b/FoliaPhantom/src/main/java/summer/foliaPhantom/FoliaPhantom.java
@@ -34,6 +34,8 @@ import summer.foliaPhantom.scheduler.SchedulerManager;
  */
 public class FoliaPhantom extends JavaPlugin {
 
+    // Stores whether the server environment is Folia-based, determined at startup.
+    private static boolean isFoliaServer;
     private SchedulerManager schedulerManager;
 
     // 設定から読み込んだ各プラグインのインスタンスを保持
@@ -44,6 +46,9 @@ public class FoliaPhantom extends JavaPlugin {
     @Override
     public void onLoad() {
         getLogger().info("[Phantom] === FoliaPhantom onLoad ===");
+        // Initialize server type detection. This boolean will affect how scheduling is handled.
+        isFoliaServer = detectServerType();
+
         // config.yml を生成/ロード
         saveDefaultConfig();
 
@@ -176,5 +181,29 @@ public class FoliaPhantom extends JavaPlugin {
     /**
      * 生成した各 URLClassLoader を閉じる
      */
+
+    /**
+     * Detects the server type by checking for the existence of a Folia-specific class.
+     * This method is called during onLoad to determine if Folia-specific APIs are available.
+     * @return true if a Folia-specific class (io.papermc.paper.threadedregions.RegionizedServer) is found, false otherwise.
+     */
+    private static boolean detectServerType() {
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+            Bukkit.getLogger().info("[Phantom] Detected Folia server environment.");
+            return true;
+        } catch (ClassNotFoundException e) {
+            Bukkit.getLogger().info("[Phantom] Detected Non-Folia server environment.");
+            return false;
+        }
+    }
+
+    /**
+     * Gets the detected server type.
+     * @return true if the server is determined to be a Folia server, false otherwise.
+     */
+    public static boolean isFoliaServer() {
+        return isFoliaServer;
+    }
 }
 

--- a/FoliaPhantom/src/main/java/summer/foliaPhantom/scheduler/FoliaBukkitTask.java
+++ b/FoliaPhantom/src/main/java/summer/foliaPhantom/scheduler/FoliaBukkitTask.java
@@ -7,14 +7,16 @@ public class FoliaBukkitTask implements org.bukkit.scheduler.BukkitTask {
     private final int taskId;
     private final Plugin plugin;
     private final Runnable taskRunnable; // Keep a reference if needed for re-scheduling or inspection
+    private final boolean isSync; // Stores if the task is synchronous
     private boolean cancelled = false; // Internal cancelled state
     private final BooleanSupplier externalCancelState; // Supplier for Folia's task cancelled state
 
-    public FoliaBukkitTask(int taskId, Plugin plugin, Runnable taskRunnable, BooleanSupplier externalCancelState) {
+    public FoliaBukkitTask(int taskId, Plugin plugin, Runnable taskRunnable, BooleanSupplier externalCancelState, boolean isSync) {
         this.taskId = taskId;
         this.plugin = plugin;
         this.taskRunnable = taskRunnable;
         this.externalCancelState = externalCancelState;
+        this.isSync = isSync;
     }
 
     @Override
@@ -29,12 +31,7 @@ public class FoliaBukkitTask implements org.bukkit.scheduler.BukkitTask {
 
     @Override
     public boolean isSync() {
-        // This is tricky. Folia's tasks are not strictly "sync" in the Bukkit sense.
-        // Most tasks run via FoliaSchedulerProxy are intended to behave like sync tasks
-        // by being region-bound or executed on a global region if no location is specified.
-        // However, truly async tasks are also proxied.
-        // For compatibility, returning true might be safer for plugins expecting sync behavior.
-        return true; // Or determine based on how it was scheduled if possible.
+        return this.isSync;
     }
 
     @Override

--- a/FoliaPhantom/src/main/java/summer/foliaPhantom/scheduler/SchedulerManager.java
+++ b/FoliaPhantom/src/main/java/summer/foliaPhantom/scheduler/SchedulerManager.java
@@ -4,6 +4,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Server;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitScheduler;
+import summer.foliaPhantom.FoliaPhantom; // Import FoliaPhantom
 import sun.misc.Unsafe; // Required for Unsafe operations
 
 import java.lang.reflect.Field;
@@ -33,6 +34,10 @@ public class SchedulerManager {
      */
     public boolean installProxy() {
         try {
+            // Determine server type (Folia or Non-Folia) to configure the proxy accordingly.
+            boolean isFolia = FoliaPhantom.isFoliaServer();
+            logger.info("[Phantom] Installing scheduler proxy for " + (isFolia ? "Folia" : "Non-Folia") + " environment.");
+
             this.schedulerAdapter = new FoliaSchedulerAdapter(this.owningPlugin);
             obtainUnsafeInstance();
 
@@ -40,7 +45,9 @@ public class SchedulerManager {
             this.proxiedBukkitScheduler = (BukkitScheduler) Proxy.newProxyInstance(
                     BukkitScheduler.class.getClassLoader(),
                     new Class<?>[]{BukkitScheduler.class},
-                    new FoliaSchedulerProxy(this.originalBukkitScheduler, this.schedulerAdapter)
+                    // Pass the detected server type to the FoliaSchedulerProxy.
+                    // This allows the proxy to adapt its behavior (e.g., pass-through on Non-Folia).
+                    new FoliaSchedulerProxy(this.originalBukkitScheduler, this.schedulerAdapter, isFolia)
             );
 
             this.serverInstance = Bukkit.getServer(); // Get current server instance


### PR DESCRIPTION
Makes the Folia-specific scheduler path more lightweight and improves the accuracy of BukkitTask metadata.

Key changes:
- Optimized argument parsing in `FoliaSchedulerProxy` when running on a Folia server. Instead of generically iterating through method arguments to find the Plugin and Runnable, it now uses direct, type-checked access based on known BukkitScheduler method signatures. This reduces overhead for each proxied task scheduling call on Folia.
- Corrected the `FoliaBukkitTask.isSync()` implementation. It now accurately reflects whether the task was scheduled synchronously or asynchronously. `FoliaSchedulerProxy` determines this based on the invoked scheduler method and passes it to the `FoliaBukkitTask` constructor.
- These changes primarily target the performance and correctness of the Folia-specific code path. The behavior on non-Folia servers remains a direct pass-through to the original scheduler.