### PR TITLE
Wrap Entity#getCustomName for thread-safety and make plugin path/command handling more robust

### DIFF
--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/core/patcher/FoliaPatcher.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/core/patcher/FoliaPatcher.java
@@ -511,6 +511,17 @@ public final class FoliaPatcher {
         }
     }
 
+    public static String safeGetCustomName(Entity entity) {
+        if (entity == null) {
+            return null;
+        }
+        try {
+            return entity.getCustomName();
+        } catch (IllegalStateException threadViolation) {
+            return null;
+        }
+    }
+
     // --- Legacy / Int-returning Method Mappings ---
 
     public static int scheduleSyncDelayedTask(BukkitScheduler s, Plugin p, Runnable r, long d) {

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/core/transformer/impl/ThreadSafetyTransformer.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/core/transformer/impl/ThreadSafetyTransformer.java
@@ -88,6 +88,14 @@ public class ThreadSafetyTransformer implements ClassTransformer {
                 }
             }
 
+            // Redirect Entity#getCustomName to avoid async thread-check violations.
+            if (isEntityOwner(owner) && "getCustomName".equals(name)
+                    && "()Ljava/lang/String;".equals(desc)) {
+                super.visitMethodInsn(Opcodes.INVOKESTATIC, PATCHER, "safeGetCustomName",
+                        "(Lorg/bukkit/entity/Entity;)Ljava/lang/String;", false);
+                return;
+            }
+
             super.visitMethodInsn(opcode, owner, name, desc, isInterface);
         }
 

--- a/folia-phantom/folia-phantom-core/src/test/java/com/patch/foliaphantom/core/transformer/impl/ThreadSafetyTransformerTest.java
+++ b/folia-phantom/folia-phantom-core/src/test/java/com/patch/foliaphantom/core/transformer/impl/ThreadSafetyTransformerTest.java
@@ -68,6 +68,24 @@ class ThreadSafetyTransformerTest {
         assertFalse(capturingMethodVisitor.lastIsInterface);
     }
 
+    @Test
+    void redirectsEntityGetCustomNameCallToFoliaPatcher() {
+        CapturingMethodVisitor capturingMethodVisitor = new CapturingMethodVisitor();
+        MethodVisitor mv = createVisitor(capturingMethodVisitor);
+
+        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
+                "org/bukkit/entity/Entity",
+                "getCustomName",
+                "()Ljava/lang/String;",
+                false);
+
+        assertEquals(Opcodes.INVOKESTATIC, capturingMethodVisitor.lastOpcode);
+        assertEquals("com/patch/foliaphantom/core/patcher/FoliaPatcher", capturingMethodVisitor.lastOwner);
+        assertEquals("safeGetCustomName", capturingMethodVisitor.lastName);
+        assertEquals("(Lorg/bukkit/entity/Entity;)Ljava/lang/String;", capturingMethodVisitor.lastDesc);
+        assertFalse(capturingMethodVisitor.lastIsInterface);
+    }
+
     private MethodVisitor createVisitor(CapturingMethodVisitor capturingMethodVisitor) {
         ThreadSafetyTransformer transformer = new ThreadSafetyTransformer(Logger.getLogger("test"));
         ClassVisitor cv = transformer.createVisitor(new ClassVisitor(Opcodes.ASM9) {

--- a/folia-phantom/folia-phantom-plugin/src/main/java/com/patch/foliaphantom/plugin/FoliaPhantomPlugin.java
+++ b/folia-phantom/folia-phantom-plugin/src/main/java/com/patch/foliaphantom/plugin/FoliaPhantomPlugin.java
@@ -2,6 +2,7 @@ package com.patch.foliaphantom.plugin;
 
 import com.patch.foliaphantom.core.patcher.FoliaPatcher;
 import org.bukkit.Bukkit;
+import org.bukkit.command.PluginCommand;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
@@ -10,7 +11,6 @@ import java.util.concurrent.TimeUnit;
 public class FoliaPhantomPlugin extends JavaPlugin {
 
     private PluginWatcher watcher;
-    private int watcherTaskId = -1;
 
     @Override
     public void onEnable() {
@@ -40,8 +40,14 @@ public class FoliaPhantomPlugin extends JavaPlugin {
 
         // Register commands
         PatchCommand patchCommand = new PatchCommand(this);
-        getCommand("foliapatch").setExecutor(patchCommand);
-        getCommand("foliapatch").setTabCompleter(patchCommand);
+        PluginCommand foliaPatchCommand = getCommand("foliapatch");
+        if (foliaPatchCommand == null) {
+            getLogger().severe("Command 'foliapatch' not found in plugin.yml. Disabling plugin for safety.");
+            Bukkit.getPluginManager().disablePlugin(this);
+            return;
+        }
+        foliaPatchCommand.setExecutor(patchCommand);
+        foliaPatchCommand.setTabCompleter(patchCommand);
 
         // Log configuration
         logConfiguration();
@@ -52,10 +58,8 @@ public class FoliaPhantomPlugin extends JavaPlugin {
     @Override
     public void onDisable() {
         // Stop the watcher task
-        if (watcherTaskId != -1) {
-            Bukkit.getAsyncScheduler().cancelTasks(this);
-            getLogger().info("Plugin watcher stopped.");
-        }
+        Bukkit.getAsyncScheduler().cancelTasks(this);
+        getLogger().info("Plugin watcher stopped.");
 
         // Print statistics
         if (watcher != null) {
@@ -78,7 +82,7 @@ public class FoliaPhantomPlugin extends JavaPlugin {
     }
 
     private void setupFolders() {
-        File serverRoot = getDataFolder().getParentFile().getParentFile();
+        File serverRoot = resolveServerRoot();
         File watchFolder = new File(serverRoot,
                 getConfig().getString("auto-patch.watch-folder", "plugins/folia-patch-queue"));
         File outputFolder = new File(serverRoot, getConfig().getString("auto-patch.output-folder", "plugins/patched"));
@@ -120,7 +124,7 @@ public class FoliaPhantomPlugin extends JavaPlugin {
     }
 
     private void logConfiguration() {
-        File serverRoot = getDataFolder().getParentFile().getParentFile();
+        File serverRoot = resolveServerRoot();
         File watchFolder = new File(serverRoot, getConfig().getString("auto-patch.watch-folder"));
         File outputFolder = new File(serverRoot, getConfig().getString("auto-patch.output-folder"));
 
@@ -140,5 +144,21 @@ public class FoliaPhantomPlugin extends JavaPlugin {
 
     public PluginWatcher getWatcher() {
         return watcher;
+    }
+
+    private File resolveServerRoot() {
+        File dataFolder = getDataFolder();
+        File pluginsFolder = dataFolder.getParentFile();
+        if (pluginsFolder == null) {
+            getLogger().warning("Failed to resolve plugins folder from data folder. Falling back to data folder.");
+            return dataFolder;
+        }
+
+        File serverRoot = pluginsFolder.getParentFile();
+        if (serverRoot == null) {
+            getLogger().warning("Failed to resolve server root from plugins folder. Falling back to plugins folder.");
+            return pluginsFolder;
+        }
+        return serverRoot;
     }
 }

--- a/folia-phantom/folia-phantom-plugin/src/main/java/com/patch/foliaphantom/plugin/PatchCommand.java
+++ b/folia-phantom/folia-phantom-plugin/src/main/java/com/patch/foliaphantom/plugin/PatchCommand.java
@@ -64,7 +64,7 @@ public class PatchCommand implements CommandExecutor, TabCompleter {
     }
 
     private void listPlugins(CommandSender sender) {
-        File serverRoot = plugin.getDataFolder().getParentFile().getParentFile();
+        File serverRoot = resolveServerRoot();
         File watchFolder = new File(serverRoot,
                 plugin.getConfig().getString("auto-patch.watch-folder", "plugins/folia-patch-queue"));
 
@@ -117,7 +117,7 @@ public class PatchCommand implements CommandExecutor, TabCompleter {
         sender.sendMessage(ChatColor.WHITE + "Skipped: " + ChatColor.YELLOW + stats.get("skipped"));
         sender.sendMessage(ChatColor.WHITE + "Failed: " + ChatColor.RED + stats.get("failed"));
 
-        File serverRoot = plugin.getDataFolder().getParentFile().getParentFile();
+        File serverRoot = resolveServerRoot();
         File watchFolder = new File(serverRoot,
                 plugin.getConfig().getString("auto-patch.watch-folder", "plugins/folia-patch-queue"));
         File outputFolder = new File(serverRoot,
@@ -128,7 +128,7 @@ public class PatchCommand implements CommandExecutor, TabCompleter {
     }
 
     private void patchPlugin(CommandSender sender, String pluginIdentifier) {
-        File serverRoot = plugin.getDataFolder().getParentFile().getParentFile();
+        File serverRoot = resolveServerRoot();
         File watchFolder = new File(serverRoot,
                 plugin.getConfig().getString("auto-patch.watch-folder", "plugins/folia-patch-queue"));
         File outputFolder = new File(serverRoot,
@@ -212,7 +212,7 @@ public class PatchCommand implements CommandExecutor, TabCompleter {
             List<String> completions = new ArrayList<>(Arrays.asList("list", "status", "reload"));
 
             // Add plugin names
-            File serverRoot = plugin.getDataFolder().getParentFile().getParentFile();
+            File serverRoot = resolveServerRoot();
             File watchFolder = new File(serverRoot,
                     plugin.getConfig().getString("auto-patch.watch-folder", "plugins/folia-patch-queue"));
 
@@ -237,5 +237,23 @@ public class PatchCommand implements CommandExecutor, TabCompleter {
         }
 
         return Collections.emptyList();
+    }
+
+    private File resolveServerRoot() {
+        File dataFolder = plugin.getDataFolder();
+        File pluginsFolder = dataFolder.getParentFile();
+        if (pluginsFolder == null) {
+            plugin.getLogger()
+                    .warning("Failed to resolve plugins folder from data folder. Falling back to data folder.");
+            return dataFolder;
+        }
+
+        File serverRoot = pluginsFolder.getParentFile();
+        if (serverRoot == null) {
+            plugin.getLogger()
+                    .warning("Failed to resolve server root from plugins folder. Falling back to plugins folder.");
+            return pluginsFolder;
+        }
+        return serverRoot;
     }
 }

--- a/folia-phantom/folia-phantom-plugin/src/main/java/com/patch/foliaphantom/plugin/PluginWatcher.java
+++ b/folia-phantom/folia-phantom-plugin/src/main/java/com/patch/foliaphantom/plugin/PluginWatcher.java
@@ -44,7 +44,7 @@ public class PluginWatcher implements Runnable {
         this.whitelistPatterns = compilePatterns(config.getStringList("filters.whitelist"));
 
         // Initialize folders
-        File serverRoot = plugin.getDataFolder().getParentFile().getParentFile();
+        File serverRoot = resolveServerRoot(plugin);
         this.watchFolder = new File(serverRoot,
                 config.getString("auto-patch.watch-folder", "plugins/folia-patch-queue"));
         this.outputFolder = new File(serverRoot, config.getString("auto-patch.output-folder", "plugins/patched"));
@@ -228,5 +228,21 @@ public class PluginWatcher implements Runnable {
         patchedCount = 0;
         skippedCount = 0;
         failedCount = 0;
+    }
+
+    private File resolveServerRoot(FoliaPhantomPlugin plugin) {
+        File dataFolder = plugin.getDataFolder();
+        File pluginsFolder = dataFolder.getParentFile();
+        if (pluginsFolder == null) {
+            logger.warning("Failed to resolve plugins folder from data folder. Falling back to data folder.");
+            return dataFolder;
+        }
+
+        File serverRoot = pluginsFolder.getParentFile();
+        if (serverRoot == null) {
+            logger.warning("Failed to resolve server root from plugins folder. Falling back to plugins folder.");
+            return pluginsFolder;
+        }
+        return serverRoot;
     }
 }


### PR DESCRIPTION
### Motivation
- Avoid async thread-check violations when accessing entity custom names and make file path resolution resilient to unexpected `dataFolder` layouts.
- Prevent crashes from missing command registrations and simplify watcher task lifecycle handling.

### Description
- Add `FoliaPatcher.safeGetCustomName(Entity)` which returns `null` on `IllegalStateException` to avoid thread-violation crashes when calling `getCustomName` off the main thread.
- Update `ThreadSafetyTransformer` to rewrite `Entity#getCustomName` calls to `FoliaPatcher.safeGetCustomName` so transformed plugins are safe on Folia region threads.
- Add a unit test `redirectsEntityGetCustomNameCallToFoliaPatcher` to `ThreadSafetyTransformerTest` to validate the bytecode rewrite.
- Improve plugin robustness by resolving the server root with a new `resolveServerRoot()` helper in `FoliaPhantomPlugin`, `PatchCommand`, and `PluginWatcher`, safely handling null parents and logging fallbacks.
- Safely obtain the `foliapatch` command via `PluginCommand` and disable the plugin if the command is missing, remove unused `watcherTaskId`, and cancel async scheduler tasks on shutdown.

### Testing
- Ran unit tests via `mvn test`, and all tests completed successfully including `ThreadSafetyTransformerTest` which contains the new `redirectsEntityGetCustomNameCallToFoliaPatcher` assertion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc598a71e883259657cdaa2cb314e1)