### PR TITLE
Optimize core patching performance with safe fast-skip and patch modes

### DIFF
--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/core/PluginPatcher.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/core/PluginPatcher.java
@@ -29,9 +29,12 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
-import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.Future;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -90,6 +93,10 @@ public class PluginPatcher {
 
     /** Statistics: number of classes skipped (no changes needed) */
     private final AtomicInteger classesSkipped = new AtomicInteger(0);
+    private final AtomicInteger classesFastSkipped = new AtomicInteger(0);
+    private final AtomicInteger classesAsmScanned = new AtomicInteger(0);
+    private final AtomicInteger classesQueued = new AtomicInteger(0);
+    private final AtomicInteger maxInFlightObserved = new AtomicInteger(0);
 
     /**
      * Creates a new PluginPatcher instance with the specified logger.
@@ -141,6 +148,10 @@ public class PluginPatcher {
         classesScanned.set(0);
         classesTransformed.set(0);
         classesSkipped.set(0);
+        classesFastSkipped.set(0);
+        classesAsmScanned.set(0);
+        classesQueued.set(0);
+        maxInFlightObserved.set(0);
 
         logger.info("[FoliaPhantom] ─────────────────────────────────────────");
         logger.info("[FoliaPhantom] Patching: " + originalJar.getName());
@@ -155,6 +166,10 @@ public class PluginPatcher {
         logger.info("[FoliaPhantom]   Classes scanned:     " + classesScanned.get());
         logger.info("[FoliaPhantom]   Classes transformed: " + classesTransformed.get());
         logger.info("[FoliaPhantom]   Classes skipped:     " + classesSkipped.get());
+        logger.info("[FoliaPhantom]   Fast-skipped:        " + classesFastSkipped.get());
+        logger.info("[FoliaPhantom]   ASM scanned:         " + classesAsmScanned.get());
+        logger.info("[FoliaPhantom]   Queued classes:      " + classesQueued.get());
+        logger.info("[FoliaPhantom]   Max in-flight:       " + maxInFlightObserved.get());
         logger.info("[FoliaPhantom] ─────────────────────────────────────────");
     }
 
@@ -166,18 +181,21 @@ public class PluginPatcher {
      * @throws IOException If an I/O error occurs
      */
     private void createPatchedJar(Path source, Path destination) throws IOException {
-        ForkJoinPool executor = ForkJoinPool.commonPool();
-
-        // Container for async class patching results
-        List<ClassPatchFuture> classFutures = new ArrayList<>(256);
-        java.util.Set<String> writtenEntries = new java.util.HashSet<>();
-        java.util.Set<String> reservedEntries = new java.util.HashSet<>();
+        int parallelism = resolveParallelism();
+        int maxInFlight = resolveMaxInFlight(parallelism);
+        ScanningClassVisitor.PatchMode patchMode = resolvePatchMode();
+        ExecutorService executor = Executors.newFixedThreadPool(parallelism);
+        CompletionService<ClassPatchResult> completionService = new ExecutorCompletionService<>(executor);
+        Set<String> writtenEntries = new HashSet<>();
+        Set<String> reservedEntries = new HashSet<>();
 
         Path parent = destination.getParent();
         if (parent != null) {
             Files.createDirectories(parent);
         }
 
+        long inputSize = 0L;
+        int inFlight = 0;
         try (ZipInputStream zis = new ZipInputStream(Files.newInputStream(source));
                 ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(destination))) {
 
@@ -204,11 +222,19 @@ public class PluginPatcher {
                 if (!isDirectory && name.endsWith(".class")) {
                     // Queue class for parallel transformation
                     byte[] classBytes = zis.readAllBytes();
+                    inputSize += classBytes.length;
                     classesScanned.incrementAndGet();
-                    classFutures.add(new ClassPatchFuture(
-                            name,
-                            executor.submit(() -> patchClass(classBytes, name))));
+                    classesQueued.incrementAndGet();
+                    completionService.submit(() -> patchClass(classBytes, name, patchMode));
+                    inFlight++;
+                    updateMaxInFlight(inFlight);
                     reservedEntries.add(name);
+                    if (inFlight >= maxInFlight) {
+                        ClassPatchResult result = takeResult(completionService);
+                        inFlight--;
+                        writeEntry(zos, result.className, result.bytes, writtenEntries);
+                        if (result.wasTransformed) classesTransformed.incrementAndGet(); else classesSkipped.incrementAndGet();
+                    }
                 } else if (!isDirectory && (name.equals("paper-plugin.yml") || name.equals("plugin.yml"))) {
                     // Modify plugin manifest to add Folia support flag
                     String originalYml = new String(zis.readAllBytes(), StandardCharsets.UTF_8);
@@ -225,26 +251,21 @@ public class PluginPatcher {
                 }
             }
 
-            // Write transformed classes
-            for (ClassPatchFuture cpf : classFutures) {
-                try {
-                    ClassPatchResult result = cpf.future.get();
-                    writeEntry(zos, cpf.name, result.bytes, writtenEntries);
-
-                    if (result.wasTransformed) {
-                        classesTransformed.incrementAndGet();
-                    } else {
-                        classesSkipped.incrementAndGet();
-                    }
-                } catch (Exception e) {
-                    throw new IOException("Failed to patch class: " + cpf.name, e);
-                }
+            while (inFlight > 0) {
+                ClassPatchResult result = takeResult(completionService);
+                inFlight--;
+                writeEntry(zos, result.className, result.bytes, writtenEntries);
+                if (result.wasTransformed) classesTransformed.incrementAndGet(); else classesSkipped.incrementAndGet();
             }
 
             // Bundle FoliaPatcher runtime classes
             bundleFoliaPatcherClasses(zos, writtenEntries);
+        } finally {
+            executor.shutdown();
         }
-        // Note: ForkJoinPool.commonPool() should not be shut down
+        logger.info("[FoliaPhantom] Mode=" + patchMode.name().toLowerCase(Locale.ROOT)
+                + ", parallelism=" + parallelism + ", maxInFlight=" + maxInFlight
+                + ", inputSize=" + inputSize + " bytes, outputSize=" + Files.size(destination) + " bytes");
     }
 
     /**
@@ -371,16 +392,21 @@ public class PluginPatcher {
      * @param className     The class name (for logging)
      * @return The patching result containing transformed bytes
      */
-    private ClassPatchResult patchClass(byte[] originalBytes, String className) {
+    private ClassPatchResult patchClass(byte[] originalBytes, String className, ScanningClassVisitor.PatchMode patchMode) {
         try {
+            if (!mayNeedPatch(originalBytes)) {
+                classesFastSkipped.incrementAndGet();
+                return new ClassPatchResult(className, originalBytes, false);
+            }
+            classesAsmScanned.incrementAndGet();
             ClassReader cr = new ClassReader(originalBytes);
 
             // Advanced scan: checks class hierarchy, field types AND method calls
             ScanningClassVisitor scanner = new ScanningClassVisitor();
             cr.accept(scanner, ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
 
-            if (!scanner.needsPatching()) {
-                return new ClassPatchResult(originalBytes, false);
+            if (!scanner.needsPatching(patchMode)) {
+                return new ClassPatchResult(className, originalBytes, false);
             }
 
             // Log the specific reasons this class requires transformation
@@ -392,18 +418,22 @@ public class PluginPatcher {
             ClassVisitor cv = cw;
 
             // Apply transformers in reverse order (so first registered runs first)
-            for (int i = transformers.size() - 1; i >= 0; i--) {
-                cv = transformers.get(i).createVisitor(cv);
+            List<ClassTransformer> selected = selectTransformers(scanner.getPatchReasons(), patchMode);
+            if (selected.isEmpty()) {
+                return new ClassPatchResult(className, originalBytes, false);
+            }
+            for (int i = selected.size() - 1; i >= 0; i--) {
+                cv = selected.get(i).createVisitor(cv);
             }
 
             cr.accept(cv, ClassReader.EXPAND_FRAMES);
 
-            return new ClassPatchResult(cw.toByteArray(), true);
+            return new ClassPatchResult(className, cw.toByteArray(), true);
 
         } catch (Exception e) {
             logger.log(Level.WARNING,
                     "[FoliaPhantom] Failed to transform " + className + ", using original", e);
-            return new ClassPatchResult(originalBytes, false);
+            return new ClassPatchResult(className, originalBytes, false);
         }
     }
 
@@ -421,6 +451,52 @@ public class PluginPatcher {
             // Add new flag
             return pluginYml.trim() + "\nfolia-supported: true\n";
         }
+    }
+
+    private static final byte[][] FAST_SCAN_TOKENS = new byte[][] {
+            "org/bukkit/".getBytes(StandardCharsets.UTF_8),
+            "io/papermc/".getBytes(StandardCharsets.UTF_8),
+            "com/destroystokyo/paper/".getBytes(StandardCharsets.UTF_8),
+            "net/kyori/".getBytes(StandardCharsets.UTF_8),
+            "com/patch/foliaphantom/".getBytes(StandardCharsets.UTF_8),
+            "runTask".getBytes(StandardCharsets.UTF_8),
+            "registerNewTeam".getBytes(StandardCharsets.UTF_8),
+            "setType".getBytes(StandardCharsets.UTF_8),
+            "createWorld".getBytes(StandardCharsets.UTF_8)
+    };
+
+    private boolean mayNeedPatch(byte[] classBytes) {
+        for (byte[] token : FAST_SCAN_TOKENS) {
+            if (indexOf(classBytes, token) >= 0) return true;
+        }
+        return false;
+    }
+
+    private int indexOf(byte[] haystack, byte[] needle) {
+        outer: for (int i = 0; i <= haystack.length - needle.length; i++) {
+            for (int j = 0; j < needle.length; j++) if (haystack[i + j] != needle[j]) continue outer;
+            return i;
+        }
+        return -1;
+    }
+
+    private List<ClassTransformer> selectTransformers(Set<ScanningClassVisitor.PatchReason> reasons, ScanningClassVisitor.PatchMode mode) {
+        if (mode == ScanningClassVisitor.PatchMode.COMPAT) return transformers;
+        if (reasons.isEmpty()) return Collections.emptyList();
+        List<ClassTransformer> selected = new ArrayList<>();
+        for (ClassTransformer transformer : transformers) if (transformer.supports(reasons)) selected.add(transformer);
+        return selected;
+    }
+
+    private int resolveParallelism() {
+        int def = Math.max(1, Math.min(Runtime.getRuntime().availableProcessors() - 1, 8));
+        return Integer.getInteger("foliaphantom.parallelism", def);
+    }
+    private int resolveMaxInFlight(int parallelism) { return Integer.getInteger("foliaphantom.maxInFlight", Math.max(16, parallelism * 4)); }
+    private ScanningClassVisitor.PatchMode resolvePatchMode() { return ScanningClassVisitor.PatchMode.fromProperty(System.getProperty("foliaphantom.patchMode")); }
+    private void updateMaxInFlight(int inFlight) { maxInFlightObserved.updateAndGet(v -> Math.max(v, inFlight)); }
+    private ClassPatchResult takeResult(CompletionService<ClassPatchResult> completionService) throws IOException {
+        try { return completionService.take().get(); } catch (Exception e) { throw new IOException("Failed to patch class", e); }
     }
 
     // =========================================================================
@@ -511,6 +587,18 @@ public class PluginPatcher {
         };
     }
 
+    public int[] getExtendedStatistics() {
+        return new int[] {
+                classesScanned.get(),
+                classesTransformed.get(),
+                classesSkipped.get(),
+                classesFastSkipped.get(),
+                classesAsmScanned.get(),
+                classesQueued.get(),
+                maxInFlightObserved.get()
+        };
+    }
+
     // =========================================================================
     // Inner Classes
     // =========================================================================
@@ -518,24 +606,13 @@ public class PluginPatcher {
     /**
      * Container for a class patching future.
      */
-    private static class ClassPatchFuture {
-        final String name;
-        final Future<ClassPatchResult> future;
-
-        ClassPatchFuture(String name, Future<ClassPatchResult> future) {
-            this.name = name;
-            this.future = future;
-        }
-    }
-
-    /**
-     * Result of a class patching operation.
-     */
     private static class ClassPatchResult {
+        final String className;
         final byte[] bytes;
         final boolean wasTransformed;
 
-        ClassPatchResult(byte[] bytes, boolean wasTransformed) {
+        ClassPatchResult(String className, byte[] bytes, boolean wasTransformed) {
+            this.className = className;
             this.bytes = bytes;
             this.wasTransformed = wasTransformed;
         }

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/core/transformer/ClassTransformer.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/core/transformer/ClassTransformer.java
@@ -7,6 +7,7 @@
 package com.patch.foliaphantom.core.transformer;
 
 import org.objectweb.asm.ClassVisitor;
+import java.util.Set;
 
 /**
  * Interface for bytecode transformers that modify plugin classes.
@@ -19,4 +20,8 @@ public interface ClassTransformer {
      * @return A new ClassVisitor instance
      */
     ClassVisitor createVisitor(ClassVisitor next);
+
+    default boolean supports(Set<ScanningClassVisitor.PatchReason> reasons) {
+        return true;
+    }
 }

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/core/transformer/ScanningClassVisitor.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/core/transformer/ScanningClassVisitor.java
@@ -36,6 +36,22 @@ import java.util.Set;
  * </ol>
  */
 public class ScanningClassVisitor extends ClassVisitor {
+    public enum PatchMode {
+        COMPAT,
+        BALANCED,
+        FAST;
+
+        public static PatchMode fromProperty(String value) {
+            if (value == null || value.isBlank()) {
+                return COMPAT;
+            }
+            return switch (value.trim().toLowerCase()) {
+                case "balanced" -> BALANCED;
+                case "fast" -> FAST;
+                default -> COMPAT;
+            };
+        }
+    }
 
     // -------------------------------------------------------------------------
     // Patching reason flags
@@ -107,8 +123,15 @@ public class ScanningClassVisitor extends ClassVisitor {
      * This guarantees 100% compatibility, ensuring no edge cases are missed
      * by the heuristic scanner.
      */
+    public boolean needsPatching(PatchMode mode) {
+        return switch (mode) {
+            case COMPAT -> true;
+            case BALANCED, FAST -> !reasons.isEmpty();
+        };
+    }
+
     public boolean needsPatching() {
-        return true;
+        return needsPatching(PatchMode.COMPAT);
     }
 
     /**

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/core/transformer/impl/EntitySchedulerTransformer.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/core/transformer/impl/EntitySchedulerTransformer.java
@@ -43,4 +43,9 @@ public class EntitySchedulerTransformer implements ClassTransformer {
             };
         }
     }
+
+    @Override
+    public boolean supports(Set<ScanningClassVisitor.PatchReason> reasons) {
+        return reasons.contains(ScanningClassVisitor.PatchReason.SCHEDULER_METHOD_CALL);
+    }
 }

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/core/transformer/impl/SchedulerClassTransformer.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/core/transformer/impl/SchedulerClassTransformer.java
@@ -104,4 +104,9 @@ public class SchedulerClassTransformer implements ClassTransformer {
             return opcode == Opcodes.INVOKEVIRTUAL || opcode == Opcodes.INVOKESPECIAL;
         }
     }
+
+    @Override
+    public boolean supports(Set<ScanningClassVisitor.PatchReason> reasons) {
+        return reasons.contains(ScanningClassVisitor.PatchReason.SCHEDULER_METHOD_CALL) || reasons.contains(ScanningClassVisitor.PatchReason.BUKKIT_RUNNABLE_INSTANCE_CALL) || reasons.contains(ScanningClassVisitor.PatchReason.EXTENDS_BUKKIT_RUNNABLE) || reasons.contains(ScanningClassVisitor.PatchReason.IMPLEMENTS_BUKKIT_INTERFACE);
+    }
 }

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/core/transformer/impl/ScoreboardClassTransformer.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/core/transformer/impl/ScoreboardClassTransformer.java
@@ -2,6 +2,8 @@ package com.patch.foliaphantom.core.transformer.impl;
 
 import com.patch.foliaphantom.core.transformer.ClassTransformer;
 import org.objectweb.asm.ClassVisitor;
+import com.patch.foliaphantom.core.transformer.ScanningClassVisitor;
+import java.util.Set;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
@@ -57,5 +59,10 @@ public class ScoreboardClassTransformer implements ClassTransformer {
 
             super.visitMethodInsn(opcode, owner, name, desc, isInterface);
         }
+    }
+
+    @Override
+    public boolean supports(Set<ScanningClassVisitor.PatchReason> reasons) {
+        return reasons.contains(ScanningClassVisitor.PatchReason.SCOREBOARD_TEAM);
     }
 }

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/core/transformer/impl/ThreadSafetyTransformer.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/core/transformer/impl/ThreadSafetyTransformer.java
@@ -103,4 +103,9 @@ public class ThreadSafetyTransformer implements ClassTransformer {
             return owner != null && owner.startsWith("org/bukkit/entity/");
         }
     }
+
+    @Override
+    public boolean supports(Set<ScanningClassVisitor.PatchReason> reasons) {
+        return reasons.contains(ScanningClassVisitor.PatchReason.BLOCK_SET_TYPE);
+    }
 }

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/core/transformer/impl/WorldGenClassTransformer.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/core/transformer/impl/WorldGenClassTransformer.java
@@ -66,4 +66,9 @@ public class WorldGenClassTransformer implements ClassTransformer {
             super.visitMethodInsn(opcode, owner, name, desc, isInterface);
         }
     }
+
+    @Override
+    public boolean supports(Set<ScanningClassVisitor.PatchReason> reasons) {
+        return reasons.contains(ScanningClassVisitor.PatchReason.WORLD_CREATION) || reasons.contains(ScanningClassVisitor.PatchReason.WORLD_GENERATOR) || reasons.contains(ScanningClassVisitor.PatchReason.WORLD_CREATOR_CONSTRUCTOR);
+    }
 }

--- a/folia-phantom/folia-phantom-core/src/test/java/com/patch/foliaphantom/core/PluginPatcherTest.java
+++ b/folia-phantom/folia-phantom-core/src/test/java/com/patch/foliaphantom/core/PluginPatcherTest.java
@@ -1,6 +1,8 @@
 package com.patch.foliaphantom.core;
 
 import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -12,6 +14,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PluginPatcherTest {
@@ -59,5 +62,39 @@ class PluginPatcherTest {
         }
 
         return jarPath;
+    }
+
+    @Test
+    void patchPluginFastSkipsUnrelatedClassAndStripsSignature() throws IOException {
+        Path input = Files.createTempFile("folia-phantom-input", ".jar");
+        Path output = Files.createTempFile("folia-phantom-output", ".jar");
+        byte[] classBytes = createSimpleClass("com/example/PlainClass");
+
+        try (OutputStream out = Files.newOutputStream(input); ZipOutputStream zos = new ZipOutputStream(out)) {
+            zos.putNextEntry(new ZipEntry("plugin.yml"));
+            zos.write("name: Demo\nfolia-supported: false\n".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+            zos.putNextEntry(new ZipEntry("META-INF/TEST.SF"));
+            zos.write("sig".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+            zos.putNextEntry(new ZipEntry("com/example/PlainClass.class"));
+            zos.write(classBytes);
+            zos.closeEntry();
+        }
+
+        patcher.patchPlugin(input.toFile(), output.toFile());
+        int[] stats = patcher.getExtendedStatistics();
+        assertTrue(stats[3] >= 1);
+        assertTrue(stats[4] == 0);
+        assertTrue(stats[0] >= 1);
+        assertTrue(PluginPatcher.isFoliaSupported(output.toFile()));
+        assertNotNull(PluginPatcher.getPluginNameFromJar(output.toFile()));
+    }
+
+    private byte[] createSimpleClass(String internalName) {
+        ClassWriter cw = new ClassWriter(0);
+        cw.visit(Opcodes.V17, Opcodes.ACC_PUBLIC, internalName, null, "java/lang/Object", null);
+        cw.visitEnd();
+        return cw.toByteArray();
     }
 }

--- a/folia-phantom/folia-phantom-core/src/test/java/com/patch/foliaphantom/core/transformer/ScanningClassVisitorTest.java
+++ b/folia-phantom/folia-phantom-core/src/test/java/com/patch/foliaphantom/core/transformer/ScanningClassVisitorTest.java
@@ -175,4 +175,13 @@ class ScanningClassVisitorTest {
         assertTrue(scanner.getPatchReasons().contains(ScanningClassVisitor.PatchReason.FIELD_TYPE_BUKKIT));
         assertTrue(scanner.getPatchReasons().contains(ScanningClassVisitor.PatchReason.SCOREBOARD_TEAM));
     }
+
+    @Test
+    void patchModeControlsNeedsPatchingForEmptyReasons() {
+        ScanningClassVisitor scanner = new ScanningClassVisitor();
+        scanner.visit(Opcodes.V17, Opcodes.ACC_PUBLIC, "com/example/Foo", null, "java/lang/Object", null);
+        assertTrue(scanner.needsPatching(ScanningClassVisitor.PatchMode.COMPAT));
+        assertFalse(scanner.needsPatching(ScanningClassVisitor.PatchMode.BALANCED));
+        assertFalse(scanner.needsPatching(ScanningClassVisitor.PatchMode.FAST));
+    }
 }


### PR DESCRIPTION
### Motivation
- Reduce CPU and memory cost of patching large/fat JARs by avoiding unnecessary ASM work while preserving v1.4.1 compatibility guarantees. 
- Provide configurable trade-offs between maximum safety and maximum throughput via a small set of modes. 
- Bound in-flight parallel class tasks to lower memory pressure and avoid using the common ForkJoinPool directly. 
- Preserve existing behavior for plugin.yml, signature stripping and runtime bundling while adding visibility into runtime statistics.

### Description
- Added a conservative byte-array pre-scan in `PluginPatcher` (`FAST_SCAN_TOKENS`) to fast-skip classes that clearly contain no Bukkit/Paper/Folia-related identifiers and immediately return the original bytes while incrementing `fastSkipped` statistics. 
- Introduced `PatchMode` (`COMPAT`, `BALANCED`, `FAST`) in `ScanningClassVisitor` with resolution from `-Dfoliaphantom.patchMode=...`; `COMPAT` keeps the old safe behavior, `BALANCED`/`FAST` allow skipping when the scanner reports no reasons. 
- Extended `ClassTransformer` with a default `supports(Set<PatchReason>)` method and updated concrete transformers to advertise which `PatchReason`s they care about, enabling selective transformer chain construction in `BALANCED`/`FAST` modes while keeping API compatibility. 
- Reworked class-processing concurrency to use a dedicated fixed `ExecutorService` + `ExecutorCompletionService` with `maxInFlight` and `parallelism` resolved from system properties (`foliaphantom.maxInFlight`, `foliaphantom.parallelism`) and defaulting to a safe CPU-bound value; ZIP writes remain single-threaded and executor is shut down at method end. 
- Added byte-array token search utilities, graceful fallback to original bytes on any exception, and selection logic that avoids creating a `ClassWriter` / running transformers when unnecessary. 
- Added extended statistics (`fastSkipped`, `asmScanned`, `queuedClasses`, `maxInFlightObserved`) and logging of mode/parallelism/input+output size; preserved `plugin.yml`/`paper-plugin.yml` modification, signature stripping and runtime bundling logic. 
- Added unit tests covering fast-skip + signature stripping and `PatchMode` semantics, and updated `ScanningClassVisitor` tests to assert the new mode behavior.

### Testing
- Added unit tests: `PluginPatcherTest.patchPluginFastSkipsUnrelatedClassAndStripsSignature` and `ScanningClassVisitorTest.patchModeControlsNeedsPatchingForEmptyReasons`, but they were not executed in CI in this environment. 
- Attempted `./gradlew :folia-phantom:folia-phantom-core:test`, but the Gradle wrapper JAR was missing in the execution environment so the Gradle run could not start (failed). 
- Attempted `mvn -f folia-phantom/pom.xml -pl folia-phantom-core test`, but Maven dependency resolution failed due to remote PaperMC repository returning HTTP 403 for `io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT`, so tests could not complete in this environment. 
- Local automated test execution could not be completed here; the test code is present and designed to run under normal network/CI conditions and should pass when dependencies and the Gradle wrapper are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f375edf8ec8325944161dc7dbd2817)