### PR TITLE
Harden plugin path handling and add method documentation

### DIFF
--- a/folia-phantom/folia-phantom-plugin/src/main/java/com/patch/foliaphantom/plugin/FoliaPhantomPlugin.java
+++ b/folia-phantom/folia-phantom-plugin/src/main/java/com/patch/foliaphantom/plugin/FoliaPhantomPlugin.java
@@ -12,6 +12,9 @@ public class FoliaPhantomPlugin extends JavaPlugin {
 
     private PluginWatcher watcher;
 
+    /**
+     * プラグイン初期化処理を行います。
+     */
     @Override
     public void onEnable() {
         // Set the static plugin reference for FoliaPatcher
@@ -55,6 +58,9 @@ public class FoliaPhantomPlugin extends JavaPlugin {
         getLogger().info("FoliaPhantom enabled successfully!");
     }
 
+    /**
+     * プラグイン終了処理を行います。
+     */
     @Override
     public void onDisable() {
         // Stop the watcher task
@@ -74,6 +80,9 @@ public class FoliaPhantomPlugin extends JavaPlugin {
         getLogger().info("FoliaPhantom disabled.");
     }
 
+    /**
+     * 起動バナーを出力します。
+     */
     private void printBanner() {
         getLogger().info("========================================");
         getLogger().info("   FoliaPhantom v" + getPluginMeta().getVersion());
@@ -81,11 +90,14 @@ public class FoliaPhantomPlugin extends JavaPlugin {
         getLogger().info("========================================");
     }
 
+    /**
+     * 監視・出力フォルダを安全に作成します。
+     */
     private void setupFolders() {
         File serverRoot = resolveServerRoot();
-        File watchFolder = new File(serverRoot,
+        File watchFolder = secureResolve(serverRoot,
                 getConfig().getString("auto-patch.watch-folder", "plugins/folia-patch-queue"));
-        File outputFolder = new File(serverRoot, getConfig().getString("auto-patch.output-folder", "plugins/patched"));
+        File outputFolder = secureResolve(serverRoot, getConfig().getString("auto-patch.output-folder", "plugins/patched"));
 
         if (!watchFolder.exists()) {
             if (watchFolder.mkdirs()) {
@@ -100,6 +112,9 @@ public class FoliaPhantomPlugin extends JavaPlugin {
         }
     }
 
+    /**
+     * 非同期ウォッチャータスクを開始します。
+     */
     private void startWatcherTask() {
         if (!getConfig().getBoolean("auto-patch.enabled", true)) {
             getLogger().warning("Auto-patching is disabled in config.yml");
@@ -123,10 +138,13 @@ public class FoliaPhantomPlugin extends JavaPlugin {
         getLogger().info("Auto-patching enabled (checking every " + checkInterval + " seconds)");
     }
 
+    /**
+     * 現在の設定値をログ出力します。
+     */
     private void logConfiguration() {
         File serverRoot = resolveServerRoot();
-        File watchFolder = new File(serverRoot, getConfig().getString("auto-patch.watch-folder"));
-        File outputFolder = new File(serverRoot, getConfig().getString("auto-patch.output-folder"));
+        File watchFolder = secureResolve(serverRoot, getConfig().getString("auto-patch.watch-folder"));
+        File outputFolder = secureResolve(serverRoot, getConfig().getString("auto-patch.output-folder"));
 
         getLogger().info("Configuration:");
         getLogger().info("  Watch Folder: " + watchFolder.getAbsolutePath());
@@ -142,10 +160,16 @@ public class FoliaPhantomPlugin extends JavaPlugin {
         }
     }
 
+    /**
+     * 初期化済みウォッチャーを返します。
+     */
     public PluginWatcher getWatcher() {
         return watcher;
     }
 
+    /**
+     * サーバールートディレクトリを解決します。
+     */
     private File resolveServerRoot() {
         File dataFolder = getDataFolder();
         File pluginsFolder = dataFolder.getParentFile();
@@ -160,5 +184,24 @@ public class FoliaPhantomPlugin extends JavaPlugin {
             return pluginsFolder;
         }
         return serverRoot;
+    }
+
+    /**
+     * サーバールート配下に限定して相対パスを解決します。
+     */
+    private File secureResolve(File serverRoot, String configuredPath) {
+        File fallback = new File(serverRoot, "plugins");
+        try {
+            File resolved = new File(serverRoot, configuredPath == null ? "" : configuredPath).getCanonicalFile();
+            File canonicalRoot = serverRoot.getCanonicalFile();
+            if (!resolved.toPath().startsWith(canonicalRoot.toPath())) {
+                getLogger().warning("Path escaped server root. Falling back to plugins folder: " + configuredPath);
+                return fallback;
+            }
+            return resolved;
+        } catch (Exception ex) {
+            getLogger().warning("Failed to resolve path safely. Falling back to plugins folder: " + configuredPath);
+            return fallback;
+        }
     }
 }

--- a/folia-phantom/folia-phantom-plugin/src/main/java/com/patch/foliaphantom/plugin/PatchCommand.java
+++ b/folia-phantom/folia-phantom-plugin/src/main/java/com/patch/foliaphantom/plugin/PatchCommand.java
@@ -16,11 +16,17 @@ public class PatchCommand implements CommandExecutor, TabCompleter {
     private final FoliaPhantomPlugin plugin;
     private final PluginPatcher patcher;
 
+    /**
+     * コマンド実行クラスを初期化します。
+     */
     public PatchCommand(FoliaPhantomPlugin plugin) {
         this.plugin = plugin;
         this.patcher = new PluginPatcher(plugin.getLogger());
     }
 
+    /**
+     * コマンドを処理します。
+     */
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (!sender.hasPermission("foliaphantom.patch")) {
@@ -54,6 +60,9 @@ public class PatchCommand implements CommandExecutor, TabCompleter {
         return true;
     }
 
+    /**
+     * ヘルプメッセージを表示します。
+     */
     private void sendHelp(CommandSender sender) {
         sender.sendMessage(ChatColor.GOLD + "=== FoliaPhantom Commands ===");
         sender.sendMessage(
@@ -63,6 +72,9 @@ public class PatchCommand implements CommandExecutor, TabCompleter {
         sender.sendMessage(ChatColor.YELLOW + "/foliapatch reload" + ChatColor.WHITE + " - Reload configuration");
     }
 
+    /**
+     * 監視フォルダ内のプラグイン一覧を表示します。
+     */
     private void listPlugins(CommandSender sender) {
         File serverRoot = resolveServerRoot();
         File watchFolder = new File(serverRoot,
@@ -99,6 +111,9 @@ public class PatchCommand implements CommandExecutor, TabCompleter {
         sender.sendMessage(ChatColor.GRAY + "Total: " + jarFiles.length + " plugin(s)");
     }
 
+    /**
+     * 現在のパッチング状態を表示します。
+     */
     private void showStatus(CommandSender sender) {
         PluginWatcher watcher = plugin.getWatcher();
         if (watcher == null) {
@@ -127,6 +142,9 @@ public class PatchCommand implements CommandExecutor, TabCompleter {
         sender.sendMessage(ChatColor.GRAY + "Output Folder: " + outputFolder.getAbsolutePath());
     }
 
+    /**
+     * 指定プラグインをパッチします。
+     */
     private void patchPlugin(CommandSender sender, String pluginIdentifier) {
         File serverRoot = resolveServerRoot();
         File watchFolder = new File(serverRoot,
@@ -183,6 +201,11 @@ public class PatchCommand implements CommandExecutor, TabCompleter {
                 return;
             }
 
+            if (!isPathInsideDirectory(targetJar, watchFolder)) {
+                sender.sendMessage(ChatColor.RED + "Invalid plugin path detected. Operation cancelled.");
+                return;
+            }
+
             File outputJar = new File(outputFolder, "patched-" + targetJar.getName());
             patcher.patchPlugin(targetJar, outputJar);
 
@@ -197,11 +220,17 @@ public class PatchCommand implements CommandExecutor, TabCompleter {
         }
     }
 
+    /**
+     * 設定をリロードします。
+     */
     private void reloadConfig(CommandSender sender) {
         plugin.reloadConfig();
         sender.sendMessage(ChatColor.GREEN + "Configuration reloaded successfully!");
     }
 
+    /**
+     * タブ補完候補を返します。
+     */
     @Override
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
         if (!sender.hasPermission("foliaphantom.patch")) {
@@ -239,6 +268,9 @@ public class PatchCommand implements CommandExecutor, TabCompleter {
         return Collections.emptyList();
     }
 
+    /**
+     * サーバールートディレクトリを解決します。
+     */
     private File resolveServerRoot() {
         File dataFolder = plugin.getDataFolder();
         File pluginsFolder = dataFolder.getParentFile();
@@ -255,5 +287,16 @@ public class PatchCommand implements CommandExecutor, TabCompleter {
             return pluginsFolder;
         }
         return serverRoot;
+    }
+
+    /**
+     * 対象パスが基準ディレクトリ配下か検証します。
+     */
+    private boolean isPathInsideDirectory(File target, File directory) {
+        try {
+            return target.getCanonicalFile().toPath().startsWith(directory.getCanonicalFile().toPath());
+        } catch (IOException e) {
+            return false;
+        }
     }
 }

--- a/folia-phantom/folia-phantom-plugin/src/main/java/com/patch/foliaphantom/plugin/PluginWatcher.java
+++ b/folia-phantom/folia-phantom-plugin/src/main/java/com/patch/foliaphantom/plugin/PluginWatcher.java
@@ -33,6 +33,9 @@ public class PluginWatcher implements Runnable {
     private int skippedCount = 0;
     private int failedCount = 0;
 
+    /**
+     * ウォッチャーを初期化します。
+     */
     public PluginWatcher(FoliaPhantomPlugin plugin) {
         this.logger = plugin.getLogger();
         this.config = plugin.getConfig();
@@ -55,6 +58,9 @@ public class PluginWatcher implements Runnable {
         createFolders();
     }
 
+    /**
+     * 必要なフォルダを作成します。
+     */
     private void createFolders() {
         if (!watchFolder.exists() && !watchFolder.mkdirs()) {
             logger.warning("Failed to create watch folder: " + watchFolder.getAbsolutePath());
@@ -69,6 +75,9 @@ public class PluginWatcher implements Runnable {
         }
     }
 
+    /**
+     * 定期実行エントリポイントです。
+     */
     @Override
     public void run() {
         if (!config.getBoolean("auto-patch.enabled", true)) {
@@ -91,6 +100,9 @@ public class PluginWatcher implements Runnable {
         }
     }
 
+    /**
+     * 監視フォルダを走査し、対象プラグインをパッチします。
+     */
     private void scanAndPatchPlugins() {
         File[] jarFiles = watchFolder.listFiles((dir, name) -> name.toLowerCase().endsWith(".jar"));
 
@@ -103,6 +115,12 @@ public class PluginWatcher implements Runnable {
         }
 
         for (File jarFile : jarFiles) {
+            if (!isPathInsideDirectory(jarFile, watchFolder)) {
+                logger.warning("Skipped suspicious path outside watch folder: " + jarFile.getPath());
+                skippedCount++;
+                continue;
+            }
+
             // Check if we've already processed this version of the file
             String fileName = jarFile.getName();
             long lastModified = jarFile.lastModified();
@@ -130,6 +148,9 @@ public class PluginWatcher implements Runnable {
         }
     }
 
+    /**
+     * 指定JARをパッチ対象にするか判定します。
+     */
     private boolean shouldPatchPlugin(File jarFile) throws IOException {
         String fileName = jarFile.getName();
 
@@ -164,6 +185,9 @@ public class PluginWatcher implements Runnable {
         return true;
     }
 
+    /**
+     * ワイルドカードパターンをコンパイルします。
+     */
     private List<Pattern> compilePatterns(List<String> wildcardPatterns) {
         List<Pattern> patterns = new ArrayList<>(wildcardPatterns.size());
         for (String pattern : wildcardPatterns) {
@@ -173,10 +197,16 @@ public class PluginWatcher implements Runnable {
         return patterns;
     }
 
+    /**
+     * ファイル名がパターン一致するか判定します。
+     */
     private boolean matchesPattern(String fileName, Pattern pattern) {
         return pattern.matcher(fileName).matches();
     }
 
+    /**
+     * 単一プラグインをパッチします。
+     */
     private void patchPlugin(File jarFile) throws IOException {
         String fileName = jarFile.getName();
         String pluginName = PluginPatcher.getPluginNameFromJar(jarFile);
@@ -214,6 +244,9 @@ public class PluginWatcher implements Runnable {
         }
     }
 
+    /**
+     * 統計情報を返します。
+     */
     public Map<String, Integer> getStatistics() {
         Map<String, Integer> stats = new HashMap<>();
         stats.put("patched", patchedCount);
@@ -223,6 +256,9 @@ public class PluginWatcher implements Runnable {
         return stats;
     }
 
+    /**
+     * 統計と処理履歴をリセットします。
+     */
     public void reset() {
         processedFiles.clear();
         patchedCount = 0;
@@ -230,6 +266,9 @@ public class PluginWatcher implements Runnable {
         failedCount = 0;
     }
 
+    /**
+     * サーバールートディレクトリを解決します。
+     */
     private File resolveServerRoot(FoliaPhantomPlugin plugin) {
         File dataFolder = plugin.getDataFolder();
         File pluginsFolder = dataFolder.getParentFile();
@@ -244,5 +283,16 @@ public class PluginWatcher implements Runnable {
             return pluginsFolder;
         }
         return serverRoot;
+    }
+
+    /**
+     * 対象パスが基準ディレクトリ配下か検証します。
+     */
+    private boolean isPathInsideDirectory(File target, File directory) {
+        try {
+            return target.getCanonicalFile().toPath().startsWith(directory.getCanonicalFile().toPath());
+        } catch (IOException e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent accidental or malicious path escape when resolving configured watch/output folders or selecting target JARs to patch by constraining operations to the server root/watch directory.
- Improve maintainability by adding lightweight method-level documentation across runtime classes.
- Keep runtime cost minimal so Folia scheduling/performance is not affected (only canonical-path checks and per-file path validation performed). 

### Description
- Added `secureResolve(File, String)` in `FoliaPhantomPlugin` to canonicalize configured paths and fall back to the `plugins` folder if the resolved path escapes the server root or fails to resolve, and replaced direct `new File(serverRoot, ...)` uses for watch/output folder resolution. (modified `FoliaPhantomPlugin.java`)
- Added `isPathInsideDirectory(File, File)` checks in `PatchCommand` and `PluginWatcher` and reject/skips files that do not canonicalize under the expected watch directory to avoid operating on unexpected paths. (modified `PatchCommand.java`, `PluginWatcher.java`)
- Added concise JavaDoc-style comments to lifecycle and helper methods in `FoliaPhantomPlugin`, `PatchCommand`, and `PluginWatcher` to clarify responsibilities and improve readability. (modified `FoliaPhantomPlugin.java`, `PatchCommand.java`, `PluginWatcher.java`)
- All checks are simple canonical-path comparisons and applied only at folder-resolution and per-file scan/patch time to minimize overhead.

### Testing
- Attempted `./gradlew test -q` but it failed because the repository is missing the Gradle wrapper JAR (`gradle/wrapper/gradle-wrapper.jar`).
- Attempted `mvn -q -f folia-phantom/pom.xml test` but the build failed during dependency resolution for `io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT` due to HTTP 403 from the PaperMC repository, so unit tests could not be run to completion.
- No automated test failures attributable to code changes could be observed due to the environment/dependency issues above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02abb22e248325aa209d2a640d2325)