### PR TITLE
Prepare FoliaPhantom 1.4.3 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,8 @@ jobs:
           PLUGIN_JAR="folia-phantom/folia-phantom-plugin/target/Folia Phantom Plugin-$VERSION.jar"
           CLI_JAR="folia-phantom/folia-phantom-cli/target/Folia Phantom CLI-$VERSION.jar"
           GUI_JAR="folia-phantom/folia-phantom-gui/target/folia-phantom-gui-$VERSION.jar"
+          GUI_DIST="folia-phantom-gui-$VERSION"
+          GUI_ZIP="$GUI_DIST.zip"
 
           # ファイルの存在確認
           for f in "$PLUGIN_JAR" "$CLI_JAR" "$GUI_JAR"; do
@@ -50,9 +52,15 @@ jobs:
             fi
           done
 
+          mkdir -p "$GUI_DIST/lib"
+          cp "$GUI_JAR" "$GUI_DIST/"
+          cp -R folia-phantom/folia-phantom-gui/target/lib/. "$GUI_DIST/lib/"
+          zip -r "$GUI_ZIP" "$GUI_DIST"
+
           echo "PLUGIN_JAR=$PLUGIN_JAR" >> "$GITHUB_OUTPUT"
           echo "CLI_JAR=$CLI_JAR" >> "$GITHUB_OUTPUT"
           echo "GUI_JAR=$GUI_JAR" >> "$GITHUB_OUTPUT"
+          echo "GUI_ZIP=$GUI_ZIP" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -64,6 +72,7 @@ jobs:
             ${{ steps.artifacts.outputs.PLUGIN_JAR }}
             ${{ steps.artifacts.outputs.CLI_JAR }}
             ${{ steps.artifacts.outputs.GUI_JAR }}
+            ${{ steps.artifacts.outputs.GUI_ZIP }}
           body: |
             ## FoliaPhantom ${{ github.ref_name }}
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'com.patch.foliaphantom'
-version = '1.4.2'
+version = '1.4.3'
 
 ext {
     asmVersion = '9.7'

--- a/build.gradle
+++ b/build.gradle
@@ -4,13 +4,13 @@ plugins {
 }
 
 group = 'com.patch.foliaphantom'
-version = '1.0.0'
+version = '1.4.2'
 
 ext {
     asmVersion = '9.7'
     paperApiVersion = '1.21.1-R0.1-SNAPSHOT'
     junitVersion = '5.10.2'
-    javafxVersion = '21.0.1'
+    javafxVersion = '21.0.11'
 }
 
 allprojects {

--- a/folia-phantom/folia-phantom-cli/pom.xml
+++ b/folia-phantom/folia-phantom-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.patch.foliaphantom</groupId>
         <artifactId>folia-phantom</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
     </parent>
 
     <artifactId>folia-phantom-cli</artifactId>

--- a/folia-phantom/folia-phantom-cli/pom.xml
+++ b/folia-phantom/folia-phantom-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.patch.foliaphantom</groupId>
         <artifactId>folia-phantom</artifactId>
-        <version>1.4.1</version>
+        <version>1.4.2</version>
     </parent>
 
     <artifactId>folia-phantom-cli</artifactId>

--- a/folia-phantom/folia-phantom-core/pom.xml
+++ b/folia-phantom/folia-phantom-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.patch.foliaphantom</groupId>
         <artifactId>folia-phantom</artifactId>
-        <version>1.4.1</version>
+        <version>1.4.2</version>
     </parent>
 
     <artifactId>folia-phantom-core</artifactId>

--- a/folia-phantom/folia-phantom-core/pom.xml
+++ b/folia-phantom/folia-phantom-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.patch.foliaphantom</groupId>
         <artifactId>folia-phantom</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
     </parent>
 
     <artifactId>folia-phantom-core</artifactId>

--- a/folia-phantom/folia-phantom-gui/pom.xml
+++ b/folia-phantom/folia-phantom-gui/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.patch.foliaphantom</groupId>
         <artifactId>folia-phantom</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
     </parent>
 
     <artifactId>folia-phantom-gui</artifactId>

--- a/folia-phantom/folia-phantom-gui/pom.xml
+++ b/folia-phantom/folia-phantom-gui/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <groupId>com.patch.foliaphantom</groupId>
         <artifactId>folia-phantom</artifactId>
-        <version>1.4.1</version>
+        <version>1.4.2</version>
     </parent>
 
     <artifactId>folia-phantom-gui</artifactId>
 
     <properties>
-        <javafx.version>21.0.1</javafx.version>
+        <javafx.version>21.0.11</javafx.version>
     </properties>
 
     <dependencies>
@@ -40,8 +40,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -54,20 +54,31 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.5.1</version>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.2</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.patch.foliaphantom.gui.Launcher</mainClass>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>lib/</classpathPrefix>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.7.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
-                            <goal>shade</goal>
+                            <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
-                            <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>com.patch.foliaphantom.gui.Launcher</mainClass>
-                                </transformer>
-                            </transformers>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                            <includeScope>runtime</includeScope>
                         </configuration>
                     </execution>
                 </executions>

--- a/folia-phantom/folia-phantom-gui/src/main/java/com/patch/foliaphantom/gui/FoliaPhantomApp.java
+++ b/folia-phantom/folia-phantom-gui/src/main/java/com/patch/foliaphantom/gui/FoliaPhantomApp.java
@@ -42,7 +42,7 @@ import java.util.logging.*;
  */
 public class FoliaPhantomApp extends Application {
 
-    private static final String VERSION = "1.4.2";
+    private static final String VERSION = "1.4.3";
 
     // UI Elements
     private TextArea statusArea;

--- a/folia-phantom/folia-phantom-plugin/pom.xml
+++ b/folia-phantom/folia-phantom-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.patch.foliaphantom</groupId>
         <artifactId>folia-phantom</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
     </parent>
 
     <artifactId>folia-phantom-plugin</artifactId>

--- a/folia-phantom/folia-phantom-plugin/pom.xml
+++ b/folia-phantom/folia-phantom-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.patch.foliaphantom</groupId>
         <artifactId>folia-phantom</artifactId>
-        <version>1.4.1</version>
+        <version>1.4.2</version>
     </parent>
 
     <artifactId>folia-phantom-plugin</artifactId>

--- a/folia-phantom/pom.xml
+++ b/folia-phantom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.patch.foliaphantom</groupId>
     <artifactId>folia-phantom</artifactId>
-    <version>1.4.1</version>
+    <version>1.4.2</version>
     <packaging>pom</packaging>
 
     <name>Folia Phantom</name>

--- a/folia-phantom/pom.xml
+++ b/folia-phantom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.patch.foliaphantom</groupId>
     <artifactId>folia-phantom</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <packaging>pom</packaging>
 
     <name>Folia Phantom</name>


### PR DESCRIPTION
## Summary
- Bump Maven, Gradle, and GUI display versions to 1.4.4
- Build release artifacts on Windows so the GUI distribution includes Windows JavaFX runtime jars
- Publish the GUI as `folia-phantom-gui-*-windows.zip` with a `Run-FoliaPhantom-GUI.bat` launcher instead of a standalone GUI JAR asset
- Keep CLI and plugin JAR assets in the release

## Verification
- `mvn test`
- `mvn package`
- `mvn clean package`