### PR TITLE
Fix Windows GUI release packaging for 1.4.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,15 +3,15 @@ name: Release
 on:
   push:
     tags:
-      - 'v*.*.*'   # v1.0.0 のようなセマンティックバージョンタグで実行
+      - 'v*.*.*'
 
 jobs:
   build-and-release:
     name: Build and Release JARs
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     permissions:
-      contents: write   # GitHub Release 作成に必要
+      contents: write
 
     steps:
       - name: Checkout repository
@@ -26,41 +26,47 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        shell: pwsh
+        run: |
+          "VERSION=$($env:GITHUB_REF_NAME -replace '^v', '')" >> $env:GITHUB_OUTPUT
 
       - name: Build all modules with Maven
-        run: mvn --batch-mode --no-transfer-progress package -DskipTests
+        run: mvn --batch-mode --no-transfer-progress clean package -DskipTests
         working-directory: folia-phantom
 
       - name: Collect release artifacts
         id: artifacts
+        shell: pwsh
         run: |
-          VERSION="${{ steps.version.outputs.VERSION }}"
-          PLUGIN_JAR="folia-phantom/folia-phantom-plugin/target/Folia Phantom Plugin-$VERSION.jar"
-          CLI_JAR="folia-phantom/folia-phantom-cli/target/Folia Phantom CLI-$VERSION.jar"
-          GUI_JAR="folia-phantom/folia-phantom-gui/target/folia-phantom-gui-$VERSION.jar"
-          GUI_DIST="folia-phantom-gui-$VERSION"
-          GUI_ZIP="$GUI_DIST.zip"
+          $version = "${{ steps.version.outputs.VERSION }}"
+          $pluginJar = "folia-phantom/folia-phantom-plugin/target/Folia Phantom Plugin-$version.jar"
+          $cliJar = "folia-phantom/folia-phantom-cli/target/Folia Phantom CLI-$version.jar"
+          $guiJar = "folia-phantom/folia-phantom-gui/target/folia-phantom-gui-$version.jar"
+          $guiDist = "folia-phantom-gui-$version-windows"
+          $guiZip = "$guiDist.zip"
 
-          # ファイルの存在確認
-          for f in "$PLUGIN_JAR" "$CLI_JAR" "$GUI_JAR"; do
-            if [ ! -f "$f" ]; then
-              echo "Required artifact not found: $f"
-              # デバッグ用にtargetの中身を表示
-              ls -R folia-phantom/*/target/
+          foreach ($file in @($pluginJar, $cliJar, $guiJar)) {
+            if (-not (Test-Path $file)) {
+              Write-Error "Required artifact not found: $file"
+              Get-ChildItem folia-phantom/*/target -Recurse
               exit 1
-            fi
-          done
+            }
+          }
 
-          mkdir -p "$GUI_DIST/lib"
-          cp "$GUI_JAR" "$GUI_DIST/"
-          cp -R folia-phantom/folia-phantom-gui/target/lib/. "$GUI_DIST/lib/"
-          zip -r "$GUI_ZIP" "$GUI_DIST"
+          New-Item -ItemType Directory -Force "$guiDist/lib" | Out-Null
+          Copy-Item $guiJar "$guiDist/"
+          Copy-Item "folia-phantom/folia-phantom-gui/target/lib/*" "$guiDist/lib/"
+          @(
+            '@echo off',
+            'cd /d "%~dp0"',
+            "java -jar `"folia-phantom-gui-$version.jar`"",
+            'pause'
+          ) | Set-Content -Encoding ASCII "$guiDist/Run-FoliaPhantom-GUI.bat"
+          Compress-Archive -Path "$guiDist" -DestinationPath "$guiZip" -Force
 
-          echo "PLUGIN_JAR=$PLUGIN_JAR" >> "$GITHUB_OUTPUT"
-          echo "CLI_JAR=$CLI_JAR" >> "$GITHUB_OUTPUT"
-          echo "GUI_JAR=$GUI_JAR" >> "$GITHUB_OUTPUT"
-          echo "GUI_ZIP=$GUI_ZIP" >> "$GITHUB_OUTPUT"
+          "PLUGIN_JAR=$pluginJar" >> $env:GITHUB_OUTPUT
+          "CLI_JAR=$cliJar" >> $env:GITHUB_OUTPUT
+          "GUI_ZIP=$guiZip" >> $env:GITHUB_OUTPUT
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -71,30 +77,16 @@ jobs:
           files: |
             ${{ steps.artifacts.outputs.PLUGIN_JAR }}
             ${{ steps.artifacts.outputs.CLI_JAR }}
-            ${{ steps.artifacts.outputs.GUI_JAR }}
             ${{ steps.artifacts.outputs.GUI_ZIP }}
           body: |
             ## FoliaPhantom ${{ github.ref_name }}
 
-            ### 同梱ファイル
-            | ファイル | 説明 |
-            |---------|------|
-            | `Folia Phantom Plugin-*.jar` | Bukkit/Paper サーバーに追加するプラグイン JAR |
-            | `Folia Phantom CLI-*.jar` | コマンドラインツール JAR（`java -jar` で実行） |
-            | `folia-phantom-gui-*.jar` | GUI（画面）付きツール JAR（ダブルクリックまたは `java -jar` で実行） |
+            ### Assets
+            | File | Description |
+            |------|-------------|
+            | `Folia Phantom Plugin-*.jar` | Bukkit/Paper plugin JAR |
+            | `Folia Phantom CLI-*.jar` | Command-line patcher JAR |
+            | `folia-phantom-gui-*-windows.zip` | Windows GUI distribution with JavaFX runtime dependencies in `lib/` |
 
-            ### 使い方
-            **プラグインとして使用する場合:**
-            ```
-            plugins/ フォルダに Folia Phantom Plugin-*.jar を配置してサーバーを起動
-            ```
-
-            **CLIとして使用する場合:**
-            ```bash
-            java -jar "Folia Phantom CLI-$VERSION.jar" <input.jar>
-            ```
-
-            **GUIとして使用する場合:**
-            ```bash
-            java -jar "folia-phantom-gui-$VERSION.jar"
-            ```
+            ### GUI usage on Windows
+            Extract `folia-phantom-gui-*-windows.zip`, then run `Run-FoliaPhantom-GUI.bat` or run the GUI JAR from inside the extracted folder.

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'com.patch.foliaphantom'
-version = '1.4.3'
+version = '1.4.4'
 
 ext {
     asmVersion = '9.7'

--- a/folia-phantom/folia-phantom-cli/pom.xml
+++ b/folia-phantom/folia-phantom-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.patch.foliaphantom</groupId>
         <artifactId>folia-phantom</artifactId>
-        <version>1.4.3</version>
+        <version>1.4.4</version>
     </parent>
 
     <artifactId>folia-phantom-cli</artifactId>

--- a/folia-phantom/folia-phantom-core/pom.xml
+++ b/folia-phantom/folia-phantom-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.patch.foliaphantom</groupId>
         <artifactId>folia-phantom</artifactId>
-        <version>1.4.3</version>
+        <version>1.4.4</version>
     </parent>
 
     <artifactId>folia-phantom-core</artifactId>

--- a/folia-phantom/folia-phantom-gui/pom.xml
+++ b/folia-phantom/folia-phantom-gui/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.patch.foliaphantom</groupId>
         <artifactId>folia-phantom</artifactId>
-        <version>1.4.3</version>
+        <version>1.4.4</version>
     </parent>
 
     <artifactId>folia-phantom-gui</artifactId>

--- a/folia-phantom/folia-phantom-gui/src/main/java/com/patch/foliaphantom/gui/FoliaPhantomApp.java
+++ b/folia-phantom/folia-phantom-gui/src/main/java/com/patch/foliaphantom/gui/FoliaPhantomApp.java
@@ -42,7 +42,7 @@ import java.util.logging.*;
  */
 public class FoliaPhantomApp extends Application {
 
-    private static final String VERSION = "1.4.3";
+    private static final String VERSION = "1.4.4";
 
     // UI Elements
     private TextArea statusArea;

--- a/folia-phantom/folia-phantom-plugin/pom.xml
+++ b/folia-phantom/folia-phantom-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.patch.foliaphantom</groupId>
         <artifactId>folia-phantom</artifactId>
-        <version>1.4.3</version>
+        <version>1.4.4</version>
     </parent>
 
     <artifactId>folia-phantom-plugin</artifactId>

--- a/folia-phantom/pom.xml
+++ b/folia-phantom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.patch.foliaphantom</groupId>
     <artifactId>folia-phantom</artifactId>
-    <version>1.4.3</version>
+    <version>1.4.4</version>
     <packaging>pom</packaging>
 
     <name>Folia Phantom</name>


### PR DESCRIPTION
## Summary
- Bump release version to 1.4.4
- Build release artifacts on Windows so the GUI distribution includes Windows JavaFX runtime jars
- Publish the GUI as `folia-phantom-gui-*-windows.zip` with a `Run-FoliaPhantom-GUI.bat` launcher instead of a standalone GUI JAR asset
- Keep CLI and plugin JAR assets in the release

## Verification
- `mvn package`
- `mvn clean package`