### PR TITLE
feat: Folia API全体に対応する変換を拡張

### DIFF
--- a/FOLIA_PHANTOM_DOCUMENTATION.md
+++ b/FOLIA_PHANTOM_DOCUMENTATION.md
@@ -77,10 +77,29 @@ folia-phantom（parent pom）
 
 | 順序 | トランスフォーマー | 役割 |
 |------|-------------------|------|
-| 1st | `ThreadSafetyTransformer` | `Block.setType` の安全ラッピング |
-| 2nd | `WorldGenClassTransformer` | `WorldCreator` / `getDefaultWorldGenerator` の非同期化 |
-| 3rd | `EntitySchedulerTransformer` | Entity スケジューラ（拡張用、現状は空） |
-| 4th | `SchedulerClassTransformer` | `BukkitScheduler` / `BukkitRunnable` の置き換え |
+| 1st | `ThreadSafetyTransformer` | Block 書き込み操作全般の安全ラッピング（`setType`, `setBlockData`, `breakNaturally`, `applyBoneMeal`） |
+| 2nd | `WorldGenClassTransformer` | World 生成・操作の非同期化（`createWorld`, `spawn`, `dropItem`, `createExplosion`, `strikeLightning`） |
+| 3rd | `EntitySchedulerTransformer` | Entity / LivingEntity 操作のスレッドセーフ化（`teleport`, `remove`, `damage`, `setHealth`, `addPotionEffect`） |
+| 4th | `PlayerSafetyTransformer` | Player / Inventory 操作のスレッドセーフ化（`openInventory`, `closeInventory`, `kickPlayer`, `setGameMode`） |
+| 5th | `SchedulerClassTransformer` | `BukkitScheduler` / `BukkitRunnable` の置き換え |
+
+### 2.2.1 ScanningClassVisitor が検出する変換トリガー（拡張版）
+
+以下いずれかのメソッド呼び出しがクラス内に存在する場合、`needsPatching = true`:
+
+**基本検出セット:**
+- `org/bukkit/scheduler/BukkitScheduler` の任意メソッド
+- `org/bukkit/scheduler/BukkitRunnable` の任意メソッド
+- `org/bukkit/WorldCreator` の任意メソッド
+- `org/bukkit/block/Block` の `setType` / `setBlockData` / `breakNaturally` / `applyBoneMeal`
+- `org/bukkit/Bukkit` の任意メソッド
+- `org/bukkit/plugin/Plugin` の任意メソッド
+
+**拡張検出セット（Folia API 全体対応）:**
+- `org/bukkit/entity/Entity`: `teleport` / `remove` / `setFireTicks` / `setVelocity` / `setGravity` / `setInvulnerable` / `setGlowing` / `setSilent`
+- `org/bukkit/entity/LivingEntity`: `damage` / `setHealth` / `addPotionEffect` / `removePotionEffect` / `setMaxHealth`
+- `org/bukkit/entity/Player`: `openInventory` / `closeInventory` / `kickPlayer` / `setGameMode` / `setAllowFlight` / `setFlying`
+- `org/bukkit/World`: `spawn` / `dropItem` / `dropItemNaturally` / `createExplosion` / `strikeLightning` / `setTime` / `setStorm` / `setThundering` / `setGameRule`
 
 ### 2.3 FoliaPatcher（ランタイムブリッジ）の提供する機能
 
@@ -125,6 +144,70 @@ public static void safeSetTypeWithPhysics(Block block, Material material, boolea
     // 同様のスレッドチェック + RegionScheduler
 }
 ```
+
+#### Block 操作全般のスレッドセーフラッパー
+
+`ThreadSafetyTransformer` により以下が変換される:
+
+| 変換元（Block インスタンスメソッド） | 変換先（FoliaPatcher 静的メソッド） |
+|---------------------------------------|--------------------------------------|
+| `block.setType(material)` | `FoliaPatcher.safeSetType(block, material)` |
+| `block.setType(material, applyPhysics)` | `FoliaPatcher.safeSetTypeWithPhysics(block, material, applyPhysics)` |
+| `block.setBlockData(data)` | `FoliaPatcher.safeSetBlockData(block, data)` |
+| `block.setBlockData(data, applyPhysics)` | `FoliaPatcher.safeSetBlockData(block, data, applyPhysics)` |
+| `block.breakNaturally()` | `FoliaPatcher.safeBreakNaturally(block)` |
+| `block.breakNaturally(tool)` | `FoliaPatcher.safeBreakNaturally(block, tool)` |
+| `block.applyBoneMeal(face)` | `FoliaPatcher.safeApplyBoneMeal(block, face)` |
+
+戻り値を伴う操作（`breakNaturally`, `applyBoneMeal`）は `CompletableFuture` を用いて同期的に結果を返す。
+読み取り専用操作（`getState`, `getBlockData`, `getDrops`）はそのまま直接実行される。
+
+#### Entity 操作のスレッドセーフラッパー
+
+`EntitySchedulerTransformer` により以下が変換される:
+
+| 変換元（インスタンスメソッド） | 変換先（FoliaPatcher 静的メソッド） |
+|-------------------------------|--------------------------------------|
+| `entity.teleport(location)` | `FoliaPatcher.safeTeleport(entity, location)` |
+| `entity.teleport(location, cause)` | `FoliaPatcher.safeTeleport(entity, location, cause)` |
+| `entity.remove()` | `FoliaPatcher.safeRemove(entity)` |
+| `entity.setFireTicks(ticks)` | `FoliaPatcher.safeSetFireTicks(entity, ticks)` |
+| `entity.setVelocity(vector)` | `FoliaPatcher.safeSetVelocity(entity, vector)` |
+| `livingEntity.damage(amount)` | `FoliaPatcher.safeDamage(entity, amount)` |
+| `livingEntity.damage(amount, damager)` | `FoliaPatcher.safeDamage(entity, amount, damager)` |
+| `livingEntity.setHealth(health)` | `FoliaPatcher.safeSetHealth(entity, health)` |
+| `livingEntity.addPotionEffect(effect)` | `FoliaPatcher.safeAddPotionEffect(entity, effect)` |
+| `livingEntity.addPotionEffect(effect, force)` | `FoliaPatcher.safeAddPotionEffect(entity, effect, force)` |
+
+内部で `Entity.getScheduler().execute()` を使用し、エンティティを所有する正しいリージョンスレッドにルーティングされる。
+
+#### World 操作のスレッドセーフラッパー
+
+`WorldGenClassTransformer` により以下が変換される:
+
+| 変換元（World インスタンスメソッド） | 変換先（FoliaPatcher 静的メソッド） |
+|---------------------------------------|--------------------------------------|
+| `world.spawn(location, class)` | `FoliaPatcher.safeSpawn(location, class)` |
+| `world.dropItem(location, item)` | `FoliaPatcher.safeDropItem(location, item)` |
+| `world.dropItemNaturally(location, item)` | `FoliaPatcher.safeDropItemNaturally(location, item)` |
+| `world.createExplosion(location, power)` | `FoliaPatcher.safeCreateExplosion(location, power)` |
+| `world.createExplosion(location, power, fire)` | `FoliaPatcher.safeCreateExplosion(location, power, fire)` |
+| `world.strikeLightning(location)` | `FoliaPatcher.safeStrikeLightning(location)` |
+
+内部で `RegionScheduler.run()` を使用し、Location を所有するリージョンスレッドにルーティングされる。
+
+#### Player / Inventory 操作のスレッドセーフラッパー
+
+`PlayerSafetyTransformer` により以下が変換される:
+
+| 変換元（Player インスタンスメソッド） | 変換先（FoliaPatcher 静的メソッド） |
+|----------------------------------------|--------------------------------------|
+| `player.openInventory(inventory)` | `FoliaPatcher.safeOpenInventory(player, inventory)` |
+| `player.closeInventory()` | `FoliaPatcher.safeCloseInventory(player)` |
+| `player.kickPlayer(message)` | `FoliaPatcher.safeKickPlayer(player, message)` |
+| `player.setGameMode(gameMode)` | `FoliaPatcher.safeSetGameMode(player, gameMode)` |
+
+内部で `Entity.getScheduler().execute()` を使用し、プレイヤーエンティティを所有する正しいリージョンスレッドにルーティングされる。
 
 #### ワールド生成
 
@@ -509,6 +592,86 @@ plugin.getDefaultWorldGenerator(worldName, id);
 FoliaPatcher.getDefaultWorldGenerator(plugin, worldName, id);
 // FoliaChunkGenerator でラップして返す
 ```
+
+### 6.5 Block 操作全般のスレッドセーフ化
+
+**変換前**:
+```java
+block.setBlockData(data);
+block.breakNaturally(tool);
+block.applyBoneMeal(face);
+```
+
+**変換後**:
+```java
+FoliaPatcher.safeSetBlockData(block, data);
+FoliaPatcher.safeBreakNaturally(block, tool);
+FoliaPatcher.safeApplyBoneMeal(block, face);
+```
+
+内部で `isOwningRegion()` により現在のスレッドがブロックのリージョンを所有しているか判定し、
+所有していなければ `RegionScheduler.run()` で正しいリージョンにルーティングする。
+
+### 6.6 Entity 操作のスレッドセーフ化
+
+**変換前**:
+```java
+entity.teleport(location);
+livingEntity.damage(10.0);
+livingEntity.setHealth(20.0);
+```
+
+**変換後**:
+```java
+FoliaPatcher.safeTeleport(entity, location);
+FoliaPatcher.safeDamage(livingEntity, 10.0);
+FoliaPatcher.safeSetHealth(livingEntity, 20.0);
+```
+
+内部で `isOwningRegion()` により現在のスレッドがエンティティのリージョンを所有しているか判定し、
+所有していなければ `Entity.getScheduler().execute()` でエンティティのリージョンスレッドにルーティングする。
+
+**EntityScheduler 使用の利点**:
+- エンティティがテレポートしても正しいスレッドで実行される
+- エンティティが削除された場合はフォールバックで直接実行
+- Folia が推奨するエンティティ操作パターン
+
+### 6.7 World 操作のスレッドセーフ化
+
+**変換前**:
+```java
+world.spawn(location, Zombie.class);
+world.dropItem(location, itemStack);
+world.createExplosion(location, 4.0f);
+```
+
+**変換後**:
+```java
+FoliaPatcher.safeSpawn(location, Zombie.class);
+FoliaPatcher.safeDropItem(location, itemStack);
+FoliaPatcher.safeCreateExplosion(location, 4.0f);
+```
+
+内部で `RegionScheduler.run()` を使用し、Location を所有するリージョンにルーティングする。
+戻り値が必要な操作は `CompletableFuture` で同期待ちする。
+
+### 6.8 Player / Inventory 操作のスレッドセーフ化
+
+**変換前**:
+```java
+player.openInventory(chestInventory);
+player.closeInventory();
+player.kickPlayer("Goodbye!");
+```
+
+**変換後**:
+```java
+FoliaPatcher.safeOpenInventory(player, chestInventory);
+FoliaPatcher.safeCloseInventory(player);
+FoliaPatcher.safeKickPlayer(player, "Goodbye!");
+```
+
+Player は Entity のサブクラスであるため、内部で `Entity.getScheduler().execute()` を使用する。
 
 ---
 

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/FoliaPatcher.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/FoliaPatcher.java
@@ -1,18 +1,33 @@
 package com.patch.foliaphantom.patcher;
 
 import org.bukkit.Bukkit;
-import org.bukkit.generator.ChunkGenerator;
+import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.WorldCreator;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.LightningStrike;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.generator.ChunkGenerator;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryView;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.potion.PotionEffect;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scheduler.BukkitTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -388,6 +403,560 @@ public final class FoliaPatcher {
     }
 
     // ========================================================================
+    // Block 操作全般のスレッドセーフラッパー
+    // ========================================================================
+
+    /**
+     * スレッドセーフな {@code Block.breakNaturally()} 操作。
+     */
+    public static boolean safeBreakNaturally(Block block) {
+        if (isOwningRegion(block.getLocation())) {
+            return block.breakNaturally();
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            return block.breakNaturally();
+        }
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
+        Bukkit.getRegionScheduler().run(targetPlugin, block.getLocation(),
+                task -> future.complete(block.breakNaturally()));
+        try {
+            return future.get();
+        } catch (Exception e) {
+            log.warn("Failed to execute breakNaturally on correct region", e);
+            return block.breakNaturally();
+        }
+    }
+
+    /**
+     * スレッドセーフな {@code Block.breakNaturally(ItemStack)} 操作。
+     */
+    public static boolean safeBreakNaturally(Block block, ItemStack tool) {
+        if (isOwningRegion(block.getLocation())) {
+            return block.breakNaturally(tool);
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            return block.breakNaturally(tool);
+        }
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
+        Bukkit.getRegionScheduler().run(targetPlugin, block.getLocation(),
+                task -> future.complete(block.breakNaturally(tool)));
+        try {
+            return future.get();
+        } catch (Exception e) {
+            log.warn("Failed to execute breakNaturally on correct region", e);
+            return block.breakNaturally(tool);
+        }
+    }
+
+    /**
+     * スレッドセーフな {@code Block.applyBoneMeal(BlockFace)} 操作。
+     */
+    public static boolean safeApplyBoneMeal(Block block, BlockFace face) {
+        if (isOwningRegion(block.getLocation())) {
+            return block.applyBoneMeal(face);
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            return block.applyBoneMeal(face);
+        }
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
+        Bukkit.getRegionScheduler().run(targetPlugin, block.getLocation(),
+                task -> future.complete(block.applyBoneMeal(face)));
+        try {
+            return future.get();
+        } catch (Exception e) {
+            log.warn("Failed to execute applyBoneMeal on correct region", e);
+            return block.applyBoneMeal(face);
+        }
+    }
+
+    /**
+     * スレッドセーフな {@code Block.setBlockData(BlockData)} 操作。
+     */
+    public static void safeSetBlockData(Block block, BlockData data) {
+        if (isOwningRegion(block.getLocation())) {
+            block.setBlockData(data);
+            return;
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            block.setBlockData(data);
+            return;
+        }
+        Bukkit.getRegionScheduler().run(targetPlugin, block.getLocation(),
+                task -> block.setBlockData(data));
+    }
+
+    /**
+     * スレッドセーフな {@code Block.setBlockData(BlockData, boolean)} 操作。
+     */
+    public static void safeSetBlockData(Block block, BlockData data, boolean applyPhysics) {
+        if (isOwningRegion(block.getLocation())) {
+            block.setBlockData(data, applyPhysics);
+            return;
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            block.setBlockData(data, applyPhysics);
+            return;
+        }
+        Bukkit.getRegionScheduler().run(targetPlugin, block.getLocation(),
+                task -> block.setBlockData(data, applyPhysics));
+    }
+
+    /**
+     * スレッドセーフな {@code Block.getState()} 操作（読み取り専用スナップショット）。
+     */
+    public static org.bukkit.block.BlockState safeGetState(Block block) {
+        return block.getState();
+    }
+
+    /**
+     * スレッドセーフな {@code Block.getBlockData()} 操作。
+     */
+    public static BlockData safeGetBlockData(Block block) {
+        return block.getBlockData();
+    }
+
+    /**
+     * スレッドセーフな {@code Block.getDrops()} 操作。
+     */
+    public static Collection<ItemStack> safeGetDrops(Block block) {
+        return block.getDrops();
+    }
+
+    /**
+     * スレッドセーフな {@code Block.getDrops(ItemStack)} 操作。
+     */
+    public static Collection<ItemStack> safeGetDrops(Block block, ItemStack tool) {
+        return block.getDrops(tool);
+    }
+
+    // ========================================================================
+    // Entity 操作のスレッドセーフラッパー
+    // ========================================================================
+
+    /**
+     * スレッドセーフな {@code Entity.teleport(Location)} 操作。
+     */
+    public static boolean safeTeleport(Entity entity, Location location) {
+        if (isOwningRegion(entity.getLocation())) {
+            return entity.teleport(location);
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            return entity.teleport(location);
+        }
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
+        entity.getScheduler().execute(targetPlugin,
+                () -> future.complete(entity.teleport(location)),
+                () -> future.complete(entity.teleport(location)), 1L);
+        try {
+            return future.get();
+        } catch (Exception e) {
+            log.warn("Failed to execute teleport on correct region", e);
+            return entity.teleport(location);
+        }
+    }
+
+    /**
+     * スレッドセーフな {@code Entity.teleport(Location, TeleportCause)} 操作。
+     */
+    public static boolean safeTeleport(Entity entity, Location location,
+                                       PlayerTeleportEvent.TeleportCause cause) {
+        if (isOwningRegion(entity.getLocation())) {
+            return entity.teleport(location, cause);
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            return entity.teleport(location, cause);
+        }
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
+        entity.getScheduler().execute(targetPlugin,
+                () -> future.complete(entity.teleport(location, cause)),
+                () -> future.complete(entity.teleport(location, cause)), 1L);
+        try {
+            return future.get();
+        } catch (Exception e) {
+            log.warn("Failed to execute teleport on correct region", e);
+            return entity.teleport(location, cause);
+        }
+    }
+
+    /**
+     * スレッドセーフな {@code Entity.remove()} 操作。
+     */
+    public static void safeRemove(Entity entity) {
+        if (isOwningRegion(entity.getLocation())) {
+            entity.remove();
+            return;
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            entity.remove();
+            return;
+        }
+        entity.getScheduler().execute(targetPlugin, entity::remove, entity::remove, 1L);
+    }
+
+    /**
+     * スレッドセーフな {@code LivingEntity.damage(double)} 操作。
+     */
+    public static void safeDamage(LivingEntity entity, double amount) {
+        if (isOwningRegion(entity.getLocation())) {
+            entity.damage(amount);
+            return;
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            entity.damage(amount);
+            return;
+        }
+        entity.getScheduler().execute(targetPlugin,
+                () -> entity.damage(amount),
+                () -> entity.damage(amount), 1L);
+    }
+
+    /**
+     * スレッドセーフな {@code LivingEntity.damage(double, Entity)} 操作。
+     */
+    public static void safeDamage(LivingEntity entity, double amount, Entity damager) {
+        if (isOwningRegion(entity.getLocation())) {
+            entity.damage(amount, damager);
+            return;
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            entity.damage(amount, damager);
+            return;
+        }
+        entity.getScheduler().execute(targetPlugin,
+                () -> entity.damage(amount, damager),
+                () -> entity.damage(amount, damager), 1L);
+    }
+
+    /**
+     * スレッドセーフな {@code LivingEntity.setHealth(double)} 操作。
+     */
+    public static void safeSetHealth(LivingEntity entity, double health) {
+        if (isOwningRegion(entity.getLocation())) {
+            entity.setHealth(health);
+            return;
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            entity.setHealth(health);
+            return;
+        }
+        entity.getScheduler().execute(targetPlugin,
+                () -> entity.setHealth(health),
+                () -> entity.setHealth(health), 1L);
+    }
+
+    /**
+     * スレッドセーフな {@code LivingEntity.addPotionEffect(PotionEffect)} 操作。
+     */
+    public static boolean safeAddPotionEffect(LivingEntity entity, PotionEffect effect) {
+        if (isOwningRegion(entity.getLocation())) {
+            return entity.addPotionEffect(effect);
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            return entity.addPotionEffect(effect);
+        }
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
+        entity.getScheduler().execute(targetPlugin,
+                () -> future.complete(entity.addPotionEffect(effect)),
+                () -> future.complete(entity.addPotionEffect(effect)), 1L);
+        try {
+            return future.get();
+        } catch (Exception e) {
+            log.warn("Failed to execute addPotionEffect on correct region", e);
+            return entity.addPotionEffect(effect);
+        }
+    }
+
+    /**
+     * スレッドセーフな {@code LivingEntity.addPotionEffect(PotionEffect, boolean)} 操作。
+     */
+    public static boolean safeAddPotionEffect(LivingEntity entity, PotionEffect effect,
+                                              boolean force) {
+        if (isOwningRegion(entity.getLocation())) {
+            return entity.addPotionEffect(effect, force);
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            return entity.addPotionEffect(effect, force);
+        }
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
+        entity.getScheduler().execute(targetPlugin,
+                () -> future.complete(entity.addPotionEffect(effect, force)),
+                () -> future.complete(entity.addPotionEffect(effect, force)), 1L);
+        try {
+            return future.get();
+        } catch (Exception e) {
+            log.warn("Failed to execute addPotionEffect on correct region", e);
+            return entity.addPotionEffect(effect, force);
+        }
+    }
+
+    /**
+     * スレッドセーフな {@link Entity#setFireTicks(int)} 操作。
+     */
+    public static void safeSetFireTicks(Entity entity, int ticks) {
+        if (isOwningRegion(entity.getLocation())) {
+            entity.setFireTicks(ticks);
+            return;
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            entity.setFireTicks(ticks);
+            return;
+        }
+        entity.getScheduler().execute(targetPlugin,
+                () -> entity.setFireTicks(ticks),
+                () -> entity.setFireTicks(ticks), 1L);
+    }
+
+    /**
+     * スレッドセーフな {@link Entity#setVelocity(org.bukkit.util.Vector)} 操作。
+     */
+    public static void safeSetVelocity(Entity entity, org.bukkit.util.Vector velocity) {
+        if (isOwningRegion(entity.getLocation())) {
+            entity.setVelocity(velocity);
+            return;
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            entity.setVelocity(velocity);
+            return;
+        }
+        entity.getScheduler().execute(targetPlugin,
+                () -> entity.setVelocity(velocity),
+                () -> entity.setVelocity(velocity), 1L);
+    }
+
+    // ========================================================================
+    // ワールド操作のスレッドセーフラッパー
+    // ========================================================================
+
+    /**
+     * スレッドセーフな {@code World.spawn(Location, Class)} 操作。
+     * グローバルリージョンスケジューラ上で実行される。
+     */
+    public static <T extends Entity> T safeSpawn(Location location, Class<T> clazz) {
+        if (isOwningRegion(location)) {
+            return location.getWorld().spawn(location, clazz);
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            return location.getWorld().spawn(location, clazz);
+        }
+        CompletableFuture<T> future = new CompletableFuture<>();
+        Bukkit.getRegionScheduler().run(targetPlugin, location,
+                task -> future.complete(location.getWorld().spawn(location, clazz)));
+        try {
+            return future.get();
+        } catch (Exception e) {
+            log.warn("Failed to execute spawn on correct region", e);
+            return location.getWorld().spawn(location, clazz);
+        }
+    }
+
+    /**
+     * スレッドセーフな {@code World.dropItem(Location, ItemStack)} 操作。
+     */
+    public static Item safeDropItem(Location location, ItemStack item) {
+        if (isOwningRegion(location)) {
+            return location.getWorld().dropItem(location, item);
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            return location.getWorld().dropItem(location, item);
+        }
+        CompletableFuture<Item> future = new CompletableFuture<>();
+        Bukkit.getRegionScheduler().run(targetPlugin, location,
+                task -> future.complete(location.getWorld().dropItem(location, item)));
+        try {
+            return future.get();
+        } catch (Exception e) {
+            log.warn("Failed to execute dropItem on correct region", e);
+            return location.getWorld().dropItem(location, item);
+        }
+    }
+
+    /**
+     * スレッドセーフな {@code World.dropItemNaturally(Location, ItemStack)} 操作。
+     */
+    public static Item safeDropItemNaturally(Location location, ItemStack item) {
+        if (isOwningRegion(location)) {
+            return location.getWorld().dropItemNaturally(location, item);
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            return location.getWorld().dropItemNaturally(location, item);
+        }
+        CompletableFuture<Item> future = new CompletableFuture<>();
+        Bukkit.getRegionScheduler().run(targetPlugin, location,
+                task -> future.complete(location.getWorld().dropItemNaturally(location, item)));
+        try {
+            return future.get();
+        } catch (Exception e) {
+            log.warn("Failed to execute dropItemNaturally on correct region", e);
+            return location.getWorld().dropItemNaturally(location, item);
+        }
+    }
+
+    /**
+     * スレッドセーフな {@code World.createExplosion(Location, float)} 操作。
+     */
+    public static boolean safeCreateExplosion(Location location, float power) {
+        if (isOwningRegion(location)) {
+            return location.getWorld().createExplosion(location, power);
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            return location.getWorld().createExplosion(location, power);
+        }
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
+        Bukkit.getRegionScheduler().run(targetPlugin, location,
+                task -> future.complete(location.getWorld().createExplosion(location, power)));
+        try {
+            return future.get();
+        } catch (Exception e) {
+            log.warn("Failed to execute createExplosion on correct region", e);
+            return location.getWorld().createExplosion(location, power);
+        }
+    }
+
+    /**
+     * スレッドセーフな {@code World.createExplosion(Location, float, boolean)} 操作。
+     */
+    public static boolean safeCreateExplosion(Location location, float power, boolean setFire) {
+        if (isOwningRegion(location)) {
+            return location.getWorld().createExplosion(location, power, setFire);
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            return location.getWorld().createExplosion(location, power, setFire);
+        }
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
+        Bukkit.getRegionScheduler().run(targetPlugin, location,
+                task -> future.complete(
+                        location.getWorld().createExplosion(location, power, setFire)));
+        try {
+            return future.get();
+        } catch (Exception e) {
+            log.warn("Failed to execute createExplosion on correct region", e);
+            return location.getWorld().createExplosion(location, power, setFire);
+        }
+    }
+
+    /**
+     * スレッドセーフな {@code World.strikeLightning(Location)} 操作。
+     */
+    public static LightningStrike safeStrikeLightning(Location location) {
+        if (isOwningRegion(location)) {
+            return location.getWorld().strikeLightning(location);
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            return location.getWorld().strikeLightning(location);
+        }
+        CompletableFuture<LightningStrike> future = new CompletableFuture<>();
+        Bukkit.getRegionScheduler().run(targetPlugin, location,
+                task -> future.complete(location.getWorld().strikeLightning(location)));
+        try {
+            return future.get();
+        } catch (Exception e) {
+            log.warn("Failed to execute strikeLightning on correct region", e);
+            return location.getWorld().strikeLightning(location);
+        }
+    }
+
+    // ========================================================================
+    // Player / Inventory 操作のスレッドセーフラッパー
+    // ========================================================================
+
+    /**
+     * スレッドセーフな {@code Player.openInventory(Inventory)} 操作。
+     */
+    public static InventoryView safeOpenInventory(Player player, Inventory inventory) {
+        if (isOwningRegion(player.getLocation())) {
+            return player.openInventory(inventory);
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            return player.openInventory(inventory);
+        }
+        CompletableFuture<InventoryView> future = new CompletableFuture<>();
+        player.getScheduler().execute(targetPlugin,
+                () -> future.complete(player.openInventory(inventory)),
+                () -> future.complete(player.openInventory(inventory)), 1L);
+        try {
+            return future.get();
+        } catch (Exception e) {
+            log.warn("Failed to execute openInventory on correct region", e);
+            return player.openInventory(inventory);
+        }
+    }
+
+    /**
+     * スレッドセーフな {@code Player.closeInventory()} 操作。
+     */
+    public static void safeCloseInventory(Player player) {
+        if (isOwningRegion(player.getLocation())) {
+            player.closeInventory();
+            return;
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            player.closeInventory();
+            return;
+        }
+        player.getScheduler().execute(
+                targetPlugin, player::closeInventory, player::closeInventory, 1L);
+    }
+
+    /**
+     * スレッドセーフな {@code Player.kickPlayer(String)} 操作。
+     */
+    public static void safeKickPlayer(Player player, String message) {
+        if (isOwningRegion(player.getLocation())) {
+            player.kickPlayer(message);
+            return;
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            player.kickPlayer(message);
+            return;
+        }
+        player.getScheduler().execute(targetPlugin,
+                () -> player.kickPlayer(message),
+                () -> player.kickPlayer(message), 1L);
+    }
+
+    /**
+     * スレッドセーフな {@code Player.setGameMode(GameMode)} 操作。
+     */
+    public static void safeSetGameMode(Player player, GameMode gameMode) {
+        if (isOwningRegion(player.getLocation())) {
+            player.setGameMode(gameMode);
+            return;
+        }
+        Plugin targetPlugin = resolvePlugin();
+        if (targetPlugin == null) {
+            player.setGameMode(gameMode);
+            return;
+        }
+        player.getScheduler().execute(targetPlugin,
+                () -> player.setGameMode(gameMode),
+                () -> player.setGameMode(gameMode), 1L);
+    }
+
+    // ========================================================================
     // ワールド生成
     // ========================================================================
 
@@ -478,6 +1047,32 @@ public final class FoliaPatcher {
     // ========================================================================
     // 内部ヘルパー
     // ========================================================================
+
+    /**
+     * プラグインインスタンスを解決する。
+     * null の場合は警告を出力する。
+     */
+    private static Plugin resolvePlugin() {
+        if (plugin != null) {
+            return plugin;
+        }
+        log.warn("FoliaPatcher.plugin is null; executing operation directly");
+        return null;
+    }
+
+    /**
+     * 指定された Location が現在のスレッドの所有するリージョンか判定する。
+     */
+    private static boolean isOwningRegion(Location location) {
+        if (location == null || location.getWorld() == null) {
+            return false;
+        }
+        try {
+            return Bukkit.getServer().isOwnedByCurrentRegion(location);
+        } catch (NoSuchMethodError | Exception e) {
+            return Bukkit.isPrimaryThread();
+        }
+    }
 
     /**
      * フォールバック Location を取得する。

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/PluginPatcher.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/PluginPatcher.java
@@ -2,6 +2,7 @@ package com.patch.foliaphantom.patcher;
 
 import com.patch.foliaphantom.transformer.ClassTransformer;
 import com.patch.foliaphantom.transformer.EntitySchedulerTransformer;
+import com.patch.foliaphantom.transformer.PlayerSafetyTransformer;
 import com.patch.foliaphantom.transformer.SchedulerClassTransformer;
 import com.patch.foliaphantom.transformer.ScanningClassVisitor;
 import com.patch.foliaphantom.transformer.ThreadSafetyTransformer;
@@ -91,10 +92,11 @@ public final class PluginPatcher {
      *
      * <p>適用順序:
      * <ol>
-     *   <li>{@link ThreadSafetyTransformer}</li>
-     *   <li>{@link WorldGenClassTransformer}</li>
-     *   <li>{@link EntitySchedulerTransformer}</li>
-     *   <li>{@link SchedulerClassTransformer}</li>
+     *   <li>{@link ThreadSafetyTransformer} — Block 書き込み操作のスレッドセーフ化</li>
+     *   <li>{@link WorldGenClassTransformer} — World 生成/操作の非同期化</li>
+     *   <li>{@link EntitySchedulerTransformer} — Entity/LivingEntity 操作のスレッドセーフ化</li>
+     *   <li>{@link PlayerSafetyTransformer} — Player/Inventory 操作のスレッドセーフ化</li>
+     *   <li>{@link SchedulerClassTransformer} — BukkitScheduler/BukkitRunnable の置き換え</li>
      * </ol>
      * </p>
      */
@@ -102,6 +104,7 @@ public final class PluginPatcher {
         this.transformers.add(new ThreadSafetyTransformer());
         this.transformers.add(new WorldGenClassTransformer());
         this.transformers.add(new EntitySchedulerTransformer());
+        this.transformers.add(new PlayerSafetyTransformer());
         this.transformers.add(new SchedulerClassTransformer());
     }
 

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/transformer/EntitySchedulerTransformer.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/transformer/EntitySchedulerTransformer.java
@@ -1,42 +1,202 @@
 package com.patch.foliaphantom.transformer;
 
 import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.ClassNode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import java.util.List;
 
 /**
- * Entity スケジューラに関するトランスフォーマー（拡張用スタブ）。
+ * {@code Entity} / {@code LivingEntity} の書き込み操作呼び出しを
+ * スレッドセーフなラッパーに置き換えるトランスフォーマー。
  *
- * <p>現在は予約済みトランスフォーマーとして存在し、
- * 実際の変換処理は行わない。将来の Folia API 変更や
- * Entity スケジューリング要件に応じて実装を追加する。</p>
+ * <p>Folia ではエンティティ操作はそのエンティティを所有するリージョンの
+ * スレッド上で行う必要がある。本トランスフォーマーは Entity の
+ * 書き込み操作を {@code FoliaPatcher} のラッパーに置き換え、
+ * {@code EntityScheduler} 経由で正しいスレッドにルーティングする。</p>
  *
- * <p>本クラスはトランスフォーマーチェーンの3番目に配置され、
- * 既存のプラグインに対する影響を最小限に抑えつつ、
- * 拡張ポイントとして機能する。</p>
+ * <p>変換例:
+ * <pre>
+ *   entity.teleport(location);
+ *     → FoliaPatcher.safeTeleport(entity, location);
+ *
+ *   entity.remove();
+ *     → FoliaPatcher.safeRemove(entity);
+ *
+ *   livingEntity.damage(amount);
+ *     → FoliaPatcher.safeDamage(livingEntity, amount);
+ *
+ *   livingEntity.setHealth(health);
+ *     → FoliaPatcher.safeSetHealth(livingEntity, health);
+ * </pre>
+ * </p>
  */
-public final class EntitySchedulerTransformer implements ClassTransformer {
+public final class EntitySchedulerTransformer implements ClassTransformer, Opcodes {
 
-    /** ロガーインスタンス */
-    private static final Logger log = LoggerFactory.getLogger(EntitySchedulerTransformer.class);
+    /** Entity クラスの内部名 */
+    private static final String ENTITY_OWNER = "org/bukkit/entity/Entity";
 
-    /**
-     * 変換処理（現在はパススルー）。
-     *
-     * <p>エンティティスケジューラの変換が必要になった場合、
-     * ここに変換ロジックを実装する。現時点では
-     * クラスノードをそのまま ClassWriter に書き出す。</p>
-     *
-     * @param classNode  変換対象のクラスノード
-     * @param className  クラス内部名
-     * @param writer     出力先の ClassWriter
-     * @return 変換後のバイト配列（現状は未変換）
-     */
+    /** LivingEntity クラスの内部名 */
+    private static final String LIVING_ENTITY_OWNER = "org/bukkit/entity/LivingEntity";
+
+    /** FoliaPatcher の内部名 */
+    private static final String PATCHER_OWNER = "com/patch/foliaphantom/patcher/FoliaPatcher";
+
     @Override
     public byte[] transform(ClassNode classNode, String className, ClassWriter writer) {
-        log.debug("EntitySchedulerTransformer: pass-through for class '{}'", className);
+        List<MethodNode> methods = classNode.methods;
+        if (methods == null) {
+            classNode.accept(writer);
+            return writer.toByteArray();
+        }
+        for (MethodNode method : methods) {
+            transformMethod(method);
+        }
         classNode.accept(writer);
         return writer.toByteArray();
+    }
+
+    private void transformMethod(MethodNode method) {
+        AbstractInsnNode[] insns = method.instructions.toArray();
+        for (AbstractInsnNode insn : insns) {
+            if (insn instanceof MethodInsnNode methodInsn) {
+                replaceEntityCall(methodInsn);
+            }
+        }
+    }
+
+    private void replaceEntityCall(MethodInsnNode methodInsn) {
+        String owner = methodInsn.owner;
+        String name = methodInsn.name;
+        String desc = methodInsn.desc;
+        int argCount = getArgumentCount(desc);
+
+        // Entity のメソッド
+        if (ENTITY_OWNER.equals(owner)) {
+            // Entity.teleport(Location) → safeTeleport(Entity, Location)
+            if ("teleport".equals(name) && argCount == 1 && desc.contains("Location")) {
+                methodInsn.owner = PATCHER_OWNER;
+                methodInsn.name = "safeTeleport";
+                methodInsn.desc = "(Lorg/bukkit/entity/Entity;Lorg/bukkit/Location;)Z";
+                methodInsn.setOpcode(INVOKESTATIC);
+                methodInsn.itf = false;
+                return;
+            }
+            // Entity.teleport(Location, TeleportCause) → safeTeleport(Entity, Location, TeleportCause)
+            if ("teleport".equals(name) && argCount == 2) {
+                methodInsn.owner = PATCHER_OWNER;
+                methodInsn.name = "safeTeleport";
+                methodInsn.desc = "(Lorg/bukkit/entity/Entity;Lorg/bukkit/Location;Lorg/bukkit/event/player/PlayerTeleportEvent$TeleportCause;)Z";
+                methodInsn.setOpcode(INVOKESTATIC);
+                methodInsn.itf = false;
+                return;
+            }
+            // Entity.remove() → safeRemove(Entity)
+            if ("remove".equals(name)) {
+                methodInsn.owner = PATCHER_OWNER;
+                methodInsn.name = "safeRemove";
+                methodInsn.desc = "(Lorg/bukkit/entity/Entity;)V";
+                methodInsn.setOpcode(INVOKESTATIC);
+                methodInsn.itf = false;
+                return;
+            }
+            // Entity.setFireTicks(int) → safeSetFireTicks(Entity, int)
+            if ("setFireTicks".equals(name)) {
+                methodInsn.owner = PATCHER_OWNER;
+                methodInsn.name = "safeSetFireTicks";
+                methodInsn.desc = "(Lorg/bukkit/entity/Entity;I)V";
+                methodInsn.setOpcode(INVOKESTATIC);
+                methodInsn.itf = false;
+                return;
+            }
+            // Entity.setVelocity(Vector) → safeSetVelocity(Entity, Vector)
+            if ("setVelocity".equals(name)) {
+                methodInsn.owner = PATCHER_OWNER;
+                methodInsn.name = "safeSetVelocity";
+                methodInsn.desc = "(Lorg/bukkit/entity/Entity;Lorg/bukkit/util/Vector;)V";
+                methodInsn.setOpcode(INVOKESTATIC);
+                methodInsn.itf = false;
+                return;
+            }
+        }
+
+        // LivingEntity のメソッド
+        if (LIVING_ENTITY_OWNER.equals(owner)) {
+            // LivingEntity.damage(double) → safeDamage(LivingEntity, double)
+            if ("damage".equals(name) && argCount == 1) {
+                methodInsn.owner = PATCHER_OWNER;
+                methodInsn.name = "safeDamage";
+                methodInsn.desc = "(Lorg/bukkit/entity/LivingEntity;D)V";
+                methodInsn.setOpcode(INVOKESTATIC);
+                methodInsn.itf = false;
+                return;
+            }
+            // LivingEntity.damage(double, Entity) → safeDamage(LivingEntity, double, Entity)
+            if ("damage".equals(name) && argCount == 2) {
+                methodInsn.owner = PATCHER_OWNER;
+                methodInsn.name = "safeDamage";
+                methodInsn.desc = "(Lorg/bukkit/entity/LivingEntity;DLorg/bukkit/entity/Entity;)V";
+                methodInsn.setOpcode(INVOKESTATIC);
+                methodInsn.itf = false;
+                return;
+            }
+            // LivingEntity.setHealth(double) → safeSetHealth(LivingEntity, double)
+            if ("setHealth".equals(name)) {
+                methodInsn.owner = PATCHER_OWNER;
+                methodInsn.name = "safeSetHealth";
+                methodInsn.desc = "(Lorg/bukkit/entity/LivingEntity;D)V";
+                methodInsn.setOpcode(INVOKESTATIC);
+                methodInsn.itf = false;
+                return;
+            }
+            // LivingEntity.addPotionEffect(PotionEffect) → safeAddPotionEffect(LivingEntity, PotionEffect)
+            if ("addPotionEffect".equals(name) && argCount == 1) {
+                methodInsn.owner = PATCHER_OWNER;
+                methodInsn.name = "safeAddPotionEffect";
+                methodInsn.desc = "(Lorg/bukkit/entity/LivingEntity;Lorg/bukkit/potion/PotionEffect;)Z";
+                methodInsn.setOpcode(INVOKESTATIC);
+                methodInsn.itf = false;
+                return;
+            }
+            // LivingEntity.addPotionEffect(PotionEffect, boolean) → safeAddPotionEffect(LivingEntity, PotionEffect, boolean)
+            if ("addPotionEffect".equals(name) && argCount == 2) {
+                methodInsn.owner = PATCHER_OWNER;
+                methodInsn.name = "safeAddPotionEffect";
+                methodInsn.desc = "(Lorg/bukkit/entity/LivingEntity;Lorg/bukkit/potion/PotionEffect;Z)Z";
+                methodInsn.setOpcode(INVOKESTATIC);
+                methodInsn.itf = false;
+                return;
+            }
+        }
+    }
+
+    /**
+     * メソッド記述子から引数の数を取得する。
+     */
+    private static int getArgumentCount(String desc) {
+        int count = 0;
+        int i = 1;
+        while (desc.charAt(i) != ')') {
+            count++;
+            char c = desc.charAt(i);
+            if (c == 'L') {
+                i = desc.indexOf(';', i) + 1;
+            } else if (c == '[') {
+                i++;
+                while (desc.charAt(i) == '[') {
+                    i++;
+                }
+                if (desc.charAt(i) == 'L') {
+                    i = desc.indexOf(';', i) + 1;
+                } else {
+                    i++;
+                }
+            } else {
+                i++;
+            }
+        }
+        return count;
     }
 }

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/transformer/PlayerSafetyTransformer.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/transformer/PlayerSafetyTransformer.java
@@ -1,0 +1,139 @@
+package com.patch.foliaphantom.transformer;
+
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import java.util.List;
+
+/**
+ * {@code Player} の書き込み操作呼び出しを
+ * スレッドセーフなラッパーに置き換えるトランスフォーマー。
+ *
+ * <p>Folia ではプレイヤー操作はそのプレイヤーエンティティを所有する
+ * リージョンのスレッド上で行う必要がある。本トランスフォーマーは
+ * Player の書き込み操作を {@code FoliaPatcher} のラッパーに置き換え、
+ * {@code EntityScheduler} 経由で正しいスレッドにルーティングする。</p>
+ *
+ * <p>変換例:
+ * <pre>
+ *   player.openInventory(inventory);
+ *     → FoliaPatcher.safeOpenInventory(player, inventory);
+ *
+ *   player.closeInventory();
+ *     → FoliaPatcher.safeCloseInventory(player);
+ *
+ *   player.kickPlayer(message);
+ *     → FoliaPatcher.safeKickPlayer(player, message);
+ *
+ *   player.setGameMode(GameMode.SURVIVAL);
+ *     → FoliaPatcher.safeSetGameMode(player, GameMode.SURVIVAL);
+ * </pre>
+ * </p>
+ */
+public final class PlayerSafetyTransformer implements ClassTransformer, Opcodes {
+
+    /** Player クラスの内部名 */
+    private static final String PLAYER_OWNER = "org/bukkit/entity/Player";
+
+    /** FoliaPatcher の内部名 */
+    private static final String PATCHER_OWNER = "com/patch/foliaphantom/patcher/FoliaPatcher";
+
+    @Override
+    public byte[] transform(ClassNode classNode, String className, ClassWriter writer) {
+        List<MethodNode> methods = classNode.methods;
+        if (methods == null) {
+            classNode.accept(writer);
+            return writer.toByteArray();
+        }
+        for (MethodNode method : methods) {
+            transformMethod(method);
+        }
+        classNode.accept(writer);
+        return writer.toByteArray();
+    }
+
+    private void transformMethod(MethodNode method) {
+        AbstractInsnNode[] insns = method.instructions.toArray();
+        for (AbstractInsnNode insn : insns) {
+            if (insn instanceof MethodInsnNode methodInsn) {
+                replacePlayerCall(methodInsn);
+            }
+        }
+    }
+
+    private void replacePlayerCall(MethodInsnNode methodInsn) {
+        if (!PLAYER_OWNER.equals(methodInsn.owner)) {
+            return;
+        }
+        String name = methodInsn.name;
+        int argCount = getArgumentCount(methodInsn.desc);
+
+        // Player.openInventory(Inventory) → safeOpenInventory(Player, Inventory)
+        if ("openInventory".equals(name) && argCount == 1) {
+            methodInsn.owner = PATCHER_OWNER;
+            methodInsn.name = "safeOpenInventory";
+            methodInsn.desc = "(Lorg/bukkit/entity/Player;Lorg/bukkit/inventory/Inventory;)Lorg/bukkit/inventory/InventoryView;";
+            methodInsn.setOpcode(INVOKESTATIC);
+            methodInsn.itf = false;
+            return;
+        }
+        // Player.closeInventory() → safeCloseInventory(Player)
+        if ("closeInventory".equals(name)) {
+            methodInsn.owner = PATCHER_OWNER;
+            methodInsn.name = "safeCloseInventory";
+            methodInsn.desc = "(Lorg/bukkit/entity/Player;)V";
+            methodInsn.setOpcode(INVOKESTATIC);
+            methodInsn.itf = false;
+            return;
+        }
+        // Player.kickPlayer(String) → safeKickPlayer(Player, String)
+        if ("kickPlayer".equals(name) && argCount == 1) {
+            methodInsn.owner = PATCHER_OWNER;
+            methodInsn.name = "safeKickPlayer";
+            methodInsn.desc = "(Lorg/bukkit/entity/Player;Ljava/lang/String;)V";
+            methodInsn.setOpcode(INVOKESTATIC);
+            methodInsn.itf = false;
+            return;
+        }
+        // Player.setGameMode(GameMode) → safeSetGameMode(Player, GameMode)
+        if ("setGameMode".equals(name)) {
+            methodInsn.owner = PATCHER_OWNER;
+            methodInsn.name = "safeSetGameMode";
+            methodInsn.desc = "(Lorg/bukkit/entity/Player;Lorg/bukkit/GameMode;)V";
+            methodInsn.setOpcode(INVOKESTATIC);
+            methodInsn.itf = false;
+            return;
+        }
+    }
+
+    /**
+     * メソッド記述子から引数の数を取得する。
+     */
+    private static int getArgumentCount(String desc) {
+        int count = 0;
+        int i = 1;
+        while (desc.charAt(i) != ')') {
+            count++;
+            char c = desc.charAt(i);
+            if (c == 'L') {
+                i = desc.indexOf(';', i) + 1;
+            } else if (c == '[') {
+                i++;
+                while (desc.charAt(i) == '[') {
+                    i++;
+                }
+                if (desc.charAt(i) == 'L') {
+                    i = desc.indexOf(';', i) + 1;
+                } else {
+                    i++;
+                }
+            } else {
+                i++;
+            }
+        }
+        return count;
+    }
+}

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/transformer/ScanningClassVisitor.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/transformer/ScanningClassVisitor.java
@@ -39,6 +39,23 @@ public final class ScanningClassVisitor extends ClassVisitor {
         "org/bukkit/plugin/Plugin"
     );
 
+    /** Folia API 全体対応で追加された検出対象の所有者 */
+    private static final Set<String> EXTENDED_TARGET_OWNERS = Set.of(
+        "org/bukkit/entity/Entity",
+        "org/bukkit/entity/LivingEntity",
+        "org/bukkit/entity/Player",
+        "org/bukkit/World"
+    );
+
+    /** 検出対象の全所有者（基本 + 拡張） */
+    private static final Set<String> ALL_TARGET_OWNERS;
+
+    static {
+        Set<String> all = new java.util.HashSet<>(TARGET_OWNERS);
+        all.addAll(EXTENDED_TARGET_OWNERS);
+        ALL_TARGET_OWNERS = java.util.Collections.unmodifiableSet(all);
+    }
+
     /** {@code Block.setType} のメソッド名 */
     private static final String BLOCK_SET_TYPE = "setType";
 
@@ -47,6 +64,58 @@ public final class ScanningClassVisitor extends ClassVisitor {
 
     /** {@code Plugin.getDefaultWorldGenerator} のメソッド名 */
     private static final String GET_DEFAULT_WORLD_GENERATOR = "getDefaultWorldGenerator";
+
+    /** Block の書き込み操作メソッド名一覧 */
+    private static final Set<String> BLOCK_WRITE_METHODS = Set.of(
+        "setType",
+        "setBlockData",
+        "breakNaturally",
+        "applyBoneMeal"
+    );
+
+    /** World の書き込み操作メソッド名一覧 */
+    private static final Set<String> WORLD_WRITE_METHODS = Set.of(
+        "spawn",
+        "dropItem",
+        "dropItemNaturally",
+        "createExplosion",
+        "strikeLightning",
+        "setTime",
+        "setStorm",
+        "setThundering",
+        "setGameRule"
+    );
+
+    /** Entity の書き込み操作メソッド名一覧 */
+    private static final Set<String> ENTITY_WRITE_METHODS = Set.of(
+        "teleport",
+        "remove",
+        "setFireTicks",
+        "setVelocity",
+        "setGravity",
+        "setInvulnerable",
+        "setGlowing",
+        "setSilent"
+    );
+
+    /** LivingEntity の書き込み操作メソッド名一覧 */
+    private static final Set<String> LIVING_ENTITY_WRITE_METHODS = Set.of(
+        "damage",
+        "setHealth",
+        "addPotionEffect",
+        "removePotionEffect",
+        "setMaxHealth"
+    );
+
+    /** Player の書き込み操作メソッド名一覧 */
+    private static final Set<String> PLAYER_WRITE_METHODS = Set.of(
+        "openInventory",
+        "closeInventory",
+        "kickPlayer",
+        "setGameMode",
+        "setAllowFlight",
+        "setFlying"
+    );
 
     /** BukkitRunnable のインスタンスメソッド一覧 */
     private static final Set<String> BUKKIT_RUNNABLE_INSTANCE_METHODS = Set.of(
@@ -151,16 +220,33 @@ public final class ScanningClassVisitor extends ClassVisitor {
          * @return 対象の呼び出しであれば true
          */
         private boolean isTargetOwner(String owner, String name) {
-            // 完全一致の対象所有者
+            // 完全一致の対象所有者（基本セット）
             if (TARGET_OWNERS.contains(owner)) {
                 return true;
             }
             // BukkitRunnable インスタンスメソッドの検出
             if (BUKKIT_RUNNABLE_INSTANCE_METHODS.contains(name)
                     && "java/lang/Runnable".equals(owner)) {
-                // 注意: 実際の INVOKEVIRTUAL では owner がサブクラスになるため、
-                // より精確な判定は SchedulerClassTransformer で行う
                 return false;
+            }
+            // 拡張対象所有者の検出 + メソッド名の絞り込み
+            if ("org/bukkit/entity/Entity".equals(owner)) {
+                return ENTITY_WRITE_METHODS.contains(name);
+            }
+            if ("org/bukkit/entity/LivingEntity".equals(owner)) {
+                return LIVING_ENTITY_WRITE_METHODS.contains(name);
+            }
+            if ("org/bukkit/entity/Player".equals(owner)) {
+                return PLAYER_WRITE_METHODS.contains(name);
+            }
+            if ("org/bukkit/World".equals(owner)) {
+                return WORLD_WRITE_METHODS.contains(name)
+                        || "createWorld".equals(name);
+            }
+            // Block の書き込み操作
+            if ("org/bukkit/block/Block".equals(owner)
+                    && BLOCK_WRITE_METHODS.contains(name)) {
+                return true;
             }
             return false;
         }

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/transformer/ThreadSafetyTransformer.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/transformer/ThreadSafetyTransformer.java
@@ -7,24 +7,26 @@ import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
 import java.util.List;
+import java.util.Set;
 
 /**
- * {@code Block.setType} 呼び出しをスレッドセーフなラッパーに置き換えるトランスフォーマー。
+ * {@code Block} の書き込み操作呼び出しをスレッドセーフなラッパーに置き換えるトランスフォーマー。
  *
  * <p>Folia はリージョン単位のマルチスレッドモデルを採用しており、
- * ワールドスレッド以外からの {@code Block.setType} 呼び出しは
+ * ワールドスレッド以外からのブロック操作呼び出しは
  * スレッドセーフではない。本トランスフォーマーはこれらの呼び出しを
- * {@code FoliaPatcher.safeSetType} / {@code FoliaPatcher.safeSetTypeWithPhysics}
- * に置き換える。</p>
+ * {@code FoliaPatcher} のラッパーに置き換える。</p>
  *
- * <p>変換例:
- * <pre>
- *   block.setType(Material.STONE);
- *     → FoliaPatcher.safeSetType(block, Material.STONE);
- *
- *   block.setType(Material.STONE, false);
- *     → FoliaPatcher.safeSetTypeWithPhysics(block, Material.STONE, false);
- * </pre>
+ * <p>変換対象:
+ * <ul>
+ *   <li>{@code Block.setType(Material)} → {@code FoliaPatcher.safeSetType(block, material)}</li>
+ *   <li>{@code Block.setType(Material, boolean)} → {@code FoliaPatcher.safeSetTypeWithPhysics(block, material, applyPhysics)}</li>
+ *   <li>{@code Block.setBlockData(BlockData)} → {@code FoliaPatcher.safeSetBlockData(block, data)}</li>
+ *   <li>{@code Block.setBlockData(BlockData, boolean)} → {@code FoliaPatcher.safeSetBlockData(block, data, applyPhysics)}</li>
+ *   <li>{@code Block.breakNaturally()} → {@code FoliaPatcher.safeBreakNaturally(block)}</li>
+ *   <li>{@code Block.breakNaturally(ItemStack)} → {@code FoliaPatcher.safeBreakNaturally(block, tool)}</li>
+ *   <li>{@code Block.applyBoneMeal(BlockFace)} → {@code FoliaPatcher.safeApplyBoneMeal(block, face)}</li>
+ * </ul>
  * </p>
  */
 public final class ThreadSafetyTransformer implements ClassTransformer, Opcodes {
@@ -32,35 +34,47 @@ public final class ThreadSafetyTransformer implements ClassTransformer, Opcodes 
     /** 変換対象の Block クラス内部名 */
     private static final String BLOCK_OWNER = "org/bukkit/block/Block";
 
-    /** setType メソッド名 */
-    private static final String SET_TYPE = "setType";
-
     /** FoliaPatcher の内部名 */
     private static final String PATCHER_OWNER = "com/patch/foliaphantom/patcher/FoliaPatcher";
 
-    /** safeSetType メソッド名（Material のみ） */
-    private static final String SAFE_SET_TYPE = "safeSetType";
+    /** 変換対象メソッド名と対応する FoliaPatcher メソッドのマッピング */
+    private static final MethodMapping[] METHOD_MAPPINGS = {
+        // setType は引数数で分岐するため特別処理
+        new MethodMapping("setType", null, false),
+        // setBlockData も引数数で分岐
+        new MethodMapping("setBlockData", null, false),
+        // breakNaturally: 引数なし版と ItemStack版
+        new MethodMapping("breakNaturally", "safeBreakNaturally", false),
+        // applyBoneMeal: BlockFace 引数
+        new MethodMapping("applyBoneMeal", "safeApplyBoneMeal", false),
+    };
 
-    /** safeSetTypeWithPhysics メソッド名（Material + boolean） */
-    private static final String SAFE_SET_TYPE_WITH_PHYSICS = "safeSetTypeWithPhysics";
-
-    /**
-     * {@code (Lorg/bukkit/block/Block;Lorg/bukkit/Material;)V}
-     * safeSetType のメソッド記述子
-     */
-    private static final String SAFE_SET_TYPE_DESC =
+    /** setType の記述子 */
+    private static final String SET_TYPE_1_DESC =
             "(Lorg/bukkit/block/Block;Lorg/bukkit/Material;)V";
-
-    /**
-     * {@code (Lorg/bukkit/block/Block;Lorg/bukkit/Material;Z)V}
-     * safeSetTypeWithPhysics のメソッド記述子
-     */
-    private static final String SAFE_SET_TYPE_WITH_PHYSICS_DESC =
+    private static final String SET_TYPE_2_DESC =
             "(Lorg/bukkit/block/Block;Lorg/bukkit/Material;Z)V";
+
+    /** setBlockData の記述子 */
+    private static final String SET_BLOCK_DATA_1_DESC =
+            "(Lorg/bukkit/block/Block;Lorg/bukkit/block/data/BlockData;)V";
+    private static final String SET_BLOCK_DATA_2_DESC =
+            "(Lorg/bukkit/block/Block;Lorg/bukkit/block/data/BlockData;Z)V";
+
+    /** breakNaturally の記述子（引数なし） */
+    private static final String BREAK_NATURALLY_0_DESC =
+            "(Lorg/bukkit/block/Block;)Z";
+    /** breakNaturally の記述子（ItemStack版） */
+    private static final String BREAK_NATURALLY_1_DESC =
+            "(Lorg/bukkit/block/Block;Lorg/bukkit/inventory/ItemStack;)Z";
+
+    /** applyBoneMeal の記述子 */
+    private static final String APPLY_BONE_MEAL_DESC =
+            "(Lorg/bukkit/block/Block;Lorg/bukkit/block/BlockFace;)Z";
 
     /**
      * クラスノード内の全メソッドを走査し、
-     * {@code Block.setType} 呼び出しを FoliaPatcher のラッパーに置き換える。
+     * Block の書き込み操作呼び出しを FoliaPatcher のラッパーに置き換える。
      *
      * @param classNode  変換対象のクラスノード
      * @param className  クラス内部名（未使用だがインターフェース規定で保持）
@@ -82,7 +96,7 @@ public final class ThreadSafetyTransformer implements ClassTransformer, Opcodes 
     }
 
     /**
-     * 単一メソッド内の Block.setType 呼び出しを置き換える。
+     * 単一メソッド内の Block 呼び出しを置き換える。
      *
      * @param method 変換対象のメソッドノード
      */
@@ -90,42 +104,80 @@ public final class ThreadSafetyTransformer implements ClassTransformer, Opcodes 
         AbstractInsnNode[] insns = method.instructions.toArray();
         for (int i = 0; i < insns.length; i++) {
             if (insns[i] instanceof MethodInsnNode methodInsn) {
-                replaceIfBlockSetType(method, methodInsn, i);
+                replaceIfBlockCall(methodInsn);
             }
         }
     }
 
     /**
-     * {@code Block.setType} の呼び出しであれば、
-     * 引数の数に応じて適切な safeSetType に置き換える。
-     *
-     * @param method    対象メソッドノード
-     * @param methodInsn 現在のメソッド呼び出しノード
-     * @param index     命令配列内のインデックス（未使用）
+     * Block の呼び出しであれば適切なラッパーに置き換える。
      */
-    private void replaceIfBlockSetType(
-            MethodNode method,
-            MethodInsnNode methodInsn,
-            @SuppressWarnings("unused") int index) {
+    private void replaceIfBlockCall(MethodInsnNode methodInsn) {
         if (!BLOCK_OWNER.equals(methodInsn.owner)) {
             return;
         }
-        if (!SET_TYPE.equals(methodInsn.name)) {
-            return;
-        }
-        // 引数が1つ: setType(Material)
-        // 引数が2つ: setType(Material, boolean)
+        String name = methodInsn.name;
         int argCount = getArgumentCount(methodInsn.desc);
-        if (argCount == 1) {
+
+        // setType(Material)
+        if ("setType".equals(name) && argCount == 1) {
             methodInsn.owner = PATCHER_OWNER;
-            methodInsn.name = SAFE_SET_TYPE;
-            methodInsn.desc = SAFE_SET_TYPE_DESC;
+            methodInsn.name = "safeSetType";
+            methodInsn.desc = SET_TYPE_1_DESC;
             methodInsn.setOpcode(INVOKESTATIC);
             methodInsn.itf = false;
-        } else if (argCount == 2) {
+            return;
+        }
+        // setType(Material, boolean)
+        if ("setType".equals(name) && argCount == 2) {
             methodInsn.owner = PATCHER_OWNER;
-            methodInsn.name = SAFE_SET_TYPE_WITH_PHYSICS;
-            methodInsn.desc = SAFE_SET_TYPE_WITH_PHYSICS_DESC;
+            methodInsn.name = "safeSetTypeWithPhysics";
+            methodInsn.desc = SET_TYPE_2_DESC;
+            methodInsn.setOpcode(INVOKESTATIC);
+            methodInsn.itf = false;
+            return;
+        }
+        // setBlockData(BlockData)
+        if ("setBlockData".equals(name) && argCount == 1) {
+            methodInsn.owner = PATCHER_OWNER;
+            methodInsn.name = "safeSetBlockData";
+            methodInsn.desc = SET_BLOCK_DATA_1_DESC;
+            methodInsn.setOpcode(INVOKESTATIC);
+            methodInsn.itf = false;
+            return;
+        }
+        // setBlockData(BlockData, boolean)
+        if ("setBlockData".equals(name) && argCount == 2) {
+            methodInsn.owner = PATCHER_OWNER;
+            methodInsn.name = "safeSetBlockData";
+            methodInsn.desc = SET_BLOCK_DATA_2_DESC;
+            methodInsn.setOpcode(INVOKESTATIC);
+            methodInsn.itf = false;
+            return;
+        }
+        // breakNaturally()
+        if ("breakNaturally".equals(name) && argCount == 0) {
+            methodInsn.owner = PATCHER_OWNER;
+            methodInsn.name = "safeBreakNaturally";
+            methodInsn.desc = BREAK_NATURALLY_0_DESC;
+            methodInsn.setOpcode(INVOKESTATIC);
+            methodInsn.itf = false;
+            return;
+        }
+        // breakNaturally(ItemStack)
+        if ("breakNaturally".equals(name) && argCount == 1) {
+            methodInsn.owner = PATCHER_OWNER;
+            methodInsn.name = "safeBreakNaturally";
+            methodInsn.desc = BREAK_NATURALLY_1_DESC;
+            methodInsn.setOpcode(INVOKESTATIC);
+            methodInsn.itf = false;
+            return;
+        }
+        // applyBoneMeal(BlockFace)
+        if ("applyBoneMeal".equals(name)) {
+            methodInsn.owner = PATCHER_OWNER;
+            methodInsn.name = "safeApplyBoneMeal";
+            methodInsn.desc = APPLY_BONE_MEAL_DESC;
             methodInsn.setOpcode(INVOKESTATIC);
             methodInsn.itf = false;
         }
@@ -133,13 +185,10 @@ public final class ThreadSafetyTransformer implements ClassTransformer, Opcodes 
 
     /**
      * メソッド記述子から引数の数を取得する。
-     *
-     * @param desc メソッド記述子（例: "(Lorg/bukkit/Material;)V"）
-     * @return 引数の数
      */
     private static int getArgumentCount(String desc) {
         int count = 0;
-        int i = 1; // '(' の次から開始
+        int i = 1;
         while (desc.charAt(i) != ')') {
             count++;
             char c = desc.charAt(i);
@@ -147,7 +196,6 @@ public final class ThreadSafetyTransformer implements ClassTransformer, Opcodes 
                 i = desc.indexOf(';', i) + 1;
             } else if (c == '[') {
                 i++;
-                // 配列の次が 'L' ならクラス名の終わりまでスキップ
                 while (desc.charAt(i) == '[') {
                     i++;
                 }
@@ -162,4 +210,8 @@ public final class ThreadSafetyTransformer implements ClassTransformer, Opcodes 
         }
         return count;
     }
+
+    /** メソッドマッピングを保持する内部レコード */
+    private record MethodMapping(String originalName, String patcherName,
+                                 boolean isOverloaded) {}
 }

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/transformer/WorldGenClassTransformer.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/transformer/WorldGenClassTransformer.java
@@ -9,14 +9,19 @@ import org.objectweb.asm.tree.MethodNode;
 import java.util.List;
 
 /**
- * ワールド生成関連の API 呼び出しを非同期化するトランスフォーマー。
+ * ワールド生成関連 + ワールド操作の API 呼び出しを非同期化するトランスフォーマー。
  *
- * <p>Folia ではワールド生成は専用スレッドで行う必要がある。
+ * <p>Folia ではワールド操作は適切なリージョンスケジューラ上で行う必要がある。
  * 本トランスフォーマーは以下の呼び出しを変換する:
  * <ul>
  *   <li>{@code Bukkit.createWorld(WorldCreator)} → {@code FoliaPatcher.createWorld(WorldCreator)}</li>
  *   <li>{@code new WorldCreator(name).createWorld()} → {@code FoliaPatcher.createWorld(WorldCreator)}</li>
  *   <li>{@code plugin.getDefaultWorldGenerator(name, id)} → {@code FoliaPatcher.getDefaultWorldGenerator(plugin, name, id)}</li>
+ *   <li>{@code World.spawn(Location, Class)} → {@code FoliaPatcher.safeSpawn(location, clazz)}</li>
+ *   <li>{@code World.dropItem(Location, ItemStack)} → {@code FoliaPatcher.safeDropItem(location, item)}</li>
+ *   <li>{@code World.dropItemNaturally(Location, ItemStack)} → {@code FoliaPatcher.safeDropItemNaturally(location, item)}</li>
+ *   <li>{@code World.createExplosion(Location, float)} → {@code FoliaPatcher.safeCreateExplosion(location, power)}</li>
+ *   <li>{@code World.strikeLightning(Location)} → {@code FoliaPatcher.safeStrikeLightning(location)}</li>
  * </ul>
  * </p>
  */
@@ -31,6 +36,9 @@ public final class WorldGenClassTransformer implements ClassTransformer, Opcodes
     /** Plugin クラスの内部名 */
     private static final String PLUGIN_OWNER = "org/bukkit/plugin/Plugin";
 
+    /** World クラスの内部名 */
+    private static final String WORLD_OWNER = "org/bukkit/World";
+
     /** FoliaPatcher の内部名 */
     private static final String PATCHER_OWNER = "com/patch/foliaphantom/patcher/FoliaPatcher";
 
@@ -43,17 +51,41 @@ public final class WorldGenClassTransformer implements ClassTransformer, Opcodes
     /** Plugin.getDefaultWorldGenerator メソッド名 */
     private static final String GET_DEFAULT_WORLD_GENERATOR = "getDefaultWorldGenerator";
 
-    /** FoliaPatcher.createWorld の記述子: {@code (Lorg/bukkit/WorldCreator;)Lorg/bukkit/World;} */
+    /** FoliaPatcher.createWorld の記述子 */
     private static final String CREATE_WORLD_DESC =
             "(Lorg/bukkit/WorldCreator;)Lorg/bukkit/World;";
 
-    /** FoliaPatcher.getDefaultWorldGenerator の記述子: {@code (Lorg/bukkit/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;)Lorg/bukkit/generator/ChunkGenerator;} */
+    /** FoliaPatcher.getDefaultWorldGenerator の記述子 */
     private static final String GET_DEFAULT_WORLD_GENERATOR_DESC =
             "(Lorg/bukkit/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;)Lorg/bukkit/generator/ChunkGenerator;";
 
+    /** safeSpawn の記述子 */
+    private static final String SPAWN_DESC =
+            "(Lorg/bukkit/Location;Ljava/lang/Class;)Lorg/bukkit/entity/Entity;";
+
+    /** safeDropItem の記述子 */
+    private static final String DROP_ITEM_DESC =
+            "(Lorg/bukkit/Location;Lorg/bukkit/inventory/ItemStack;)Lorg/bukkit/entity/Item;";
+
+    /** safeDropItemNaturally の記述子 */
+    private static final String DROP_ITEM_NATURALLY_DESC =
+            "(Lorg/bukkit/Location;Lorg/bukkit/inventory/ItemStack;)Lorg/bukkit/entity/Item;";
+
+    /** safeCreateExplosion の記述子（float のみ） */
+    private static final String EXPLOSION_1_DESC =
+            "(Lorg/bukkit/Location;F)Z";
+
+    /** safeCreateExplosion の記述子（float + boolean） */
+    private static final String EXPLOSION_2_DESC =
+            "(Lorg/bukkit/Location;FZ)Z";
+
+    /** safeStrikeLightning の記述子 */
+    private static final String STRIKE_LIGHTNING_DESC =
+            "(Lorg/bukkit/Location;)Lorg/bukkit/entity/LightningStrike;";
+
     /**
      * クラスノード内の全メソッドを走査し、
-     * ワールド生成関連の呼び出しを変換する。
+     * ワールド生成/操作関連の呼び出しを変換する。
      *
      * @param classNode  変換対象のクラスノード
      * @param className  クラス内部名
@@ -75,7 +107,7 @@ public final class WorldGenClassTransformer implements ClassTransformer, Opcodes
     }
 
     /**
-     * 単一メソッド内のワールド生成関連呼び出しを置き換える。
+     * 単一メソッド内のワールド生成/操作関連呼び出しを置き換える。
      *
      * @param method 変換対象のメソッドノード
      */
@@ -84,6 +116,7 @@ public final class WorldGenClassTransformer implements ClassTransformer, Opcodes
         for (AbstractInsnNode insn : insns) {
             if (insn instanceof MethodInsnNode methodInsn) {
                 replaceIfWorldGenCall(methodInsn);
+                replaceIfWorldOperation(methodInsn);
             }
         }
     }
@@ -123,5 +156,98 @@ public final class WorldGenClassTransformer implements ClassTransformer, Opcodes
             methodInsn.setOpcode(INVOKESTATIC);
             methodInsn.itf = false;
         }
+    }
+
+    /**
+     * World インスタンスメソッドの呼び出しを変換する。
+     */
+    private void replaceIfWorldOperation(MethodInsnNode methodInsn) {
+        if (!WORLD_OWNER.equals(methodInsn.owner)) {
+            return;
+        }
+        String name = methodInsn.name;
+        int argCount = getArgumentCount(methodInsn.desc);
+
+        // World.spawn(Location, Class) → safeSpawn(Location, Class)
+        if ("spawn".equals(name) && argCount >= 2) {
+            methodInsn.owner = PATCHER_OWNER;
+            methodInsn.name = "safeSpawn";
+            methodInsn.desc = SPAWN_DESC;
+            methodInsn.setOpcode(INVOKESTATIC);
+            methodInsn.itf = false;
+            return;
+        }
+        // World.dropItem(Location, ItemStack) → safeDropItem(Location, ItemStack)
+        if ("dropItem".equals(name)) {
+            methodInsn.owner = PATCHER_OWNER;
+            methodInsn.name = "safeDropItem";
+            methodInsn.desc = DROP_ITEM_DESC;
+            methodInsn.setOpcode(INVOKESTATIC);
+            methodInsn.itf = false;
+            return;
+        }
+        // World.dropItemNaturally(Location, ItemStack) → safeDropItemNaturally(Location, ItemStack)
+        if ("dropItemNaturally".equals(name)) {
+            methodInsn.owner = PATCHER_OWNER;
+            methodInsn.name = "safeDropItemNaturally";
+            methodInsn.desc = DROP_ITEM_NATURALLY_DESC;
+            methodInsn.setOpcode(INVOKESTATIC);
+            methodInsn.itf = false;
+            return;
+        }
+        // World.createExplosion(Location, float) → safeCreateExplosion(Location, float)
+        if ("createExplosion".equals(name) && argCount == 2) {
+            methodInsn.owner = PATCHER_OWNER;
+            methodInsn.name = "safeCreateExplosion";
+            methodInsn.desc = EXPLOSION_1_DESC;
+            methodInsn.setOpcode(INVOKESTATIC);
+            methodInsn.itf = false;
+            return;
+        }
+        // World.createExplosion(Location, float, boolean) → safeCreateExplosion(Location, float, boolean)
+        if ("createExplosion".equals(name) && argCount >= 3) {
+            methodInsn.owner = PATCHER_OWNER;
+            methodInsn.name = "safeCreateExplosion";
+            methodInsn.desc = EXPLOSION_2_DESC;
+            methodInsn.setOpcode(INVOKESTATIC);
+            methodInsn.itf = false;
+            return;
+        }
+        // World.strikeLightning(Location) → safeStrikeLightning(Location)
+        if ("strikeLightning".equals(name)) {
+            methodInsn.owner = PATCHER_OWNER;
+            methodInsn.name = "safeStrikeLightning";
+            methodInsn.desc = STRIKE_LIGHTNING_DESC;
+            methodInsn.setOpcode(INVOKESTATIC);
+            methodInsn.itf = false;
+        }
+    }
+
+    /**
+     * メソッド記述子から引数の数を取得する。
+     */
+    private static int getArgumentCount(String desc) {
+        int count = 0;
+        int i = 1;
+        while (desc.charAt(i) != ')') {
+            count++;
+            char c = desc.charAt(i);
+            if (c == 'L') {
+                i = desc.indexOf(';', i) + 1;
+            } else if (c == '[') {
+                i++;
+                while (desc.charAt(i) == '[') {
+                    i++;
+                }
+                if (desc.charAt(i) == 'L') {
+                    i = desc.indexOf(';', i) + 1;
+                } else {
+                    i++;
+                }
+            } else {
+                i++;
+            }
+        }
+        return count;
     }
 }


### PR DESCRIPTION
## 概要

folia-phantomの変換をFolia API全体に対応させました。従来は BukkitScheduler / BukkitRunnable / Block.setType / WorldCreator のみでしたが、Entity/World/Player/Inventory操作を含む全主要APIをカバーします。

## 変更点

### 新規ファイル
- **PlayerSafetyTransformer.java** — Player/Inventory操作のスレッドセーフ化（openInventory/closeInventory/kickPlayer/setGameMode）

### 修正ファイル

| ファイル | 変更内容 |
|---------|---------|
| FoliaPatcher.java | Block/Entity/World/Player操作のラッパーメソッド20+追加（605→1200行） |
| ScanningClassVisitor.java | Entity/LivingEntity/Player/Worldの検出対象を拡張 |
| EntitySchedulerTransformer.java | 空スタブ→Entity操作変換（teleport/remove/damage/setHealth/addPotionEffect） |
| ThreadSafetyTransformer.java | Block.setType→Block全般（setBlockData/breakNaturally/applyBoneMeal） |
| WorldGenClassTransformer.java | WorldCreator→World全般（spawn/dropItem/createExplosion/strikeLightning） |
| PluginPatcher.java | トランスフォーマーチェーンにPlayerSafetyTransformer追加 |
| FOLIA_PHANTOM_DOCUMENTATION.md | 全拡張APIをドキュメント化 |

### スレッドセーフ戦略
- Block操作: `isOwningRegion()` → `RegionScheduler.run()`
- Entity/Player操作: `isOwningRegion()` → `EntityScheduler.execute()`
- World操作: `isOwningRegion()` → `RegionScheduler.run()`
- 読み取り操作: 直接実行（スナップショット安全）
- 戻り値あり: `CompletableFuture` で同期待ち