### PR TITLE
feat: harden v2.1 performance pipeline and release automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: /folia-phantom
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:00'
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    groups:
+      maven-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:30'
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: folia-phantom
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+          cache-dependency-path: folia-phantom/**/pom.xml
+
+      - name: Verify and package
+        run: mvn --batch-mode --no-transfer-progress --fail-at-end clean verify
+
+      - name: Stage release artifacts
+        run: |
+          set -euo pipefail
+          mkdir -p release
+          find . -path '*/target/*.jar' -type f ! -name 'original-*.jar' -print0 \
+            | xargs -0 -I{} cp '{}' release/
+          test -n "$(find release -maxdepth 1 -name '*.jar' -print -quit)"
+          cd release
+          sha256sum *.jar > SHA256SUMS
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pasta-${{ github.ref_name }}
+          path: folia-phantom/release/*
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Publish GitHub release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            folia-phantom/release/*.jar
+            folia-phantom/release/SHA256SUMS

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/PluginPatcher.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/PluginPatcher.java
@@ -128,14 +128,15 @@ public final class PluginPatcher {
         for (InputEntry entry : entries) {
             if ("plugin.yml".equals(entry.name())) {
                 byte[] modified = modifyPluginYml(entry.content());
-                prepared.add(new PreparedEntry(entry.name(), ForkJoinTask.adapt(() -> modified)));
+                prepared.add(new PreparedEntry(entry.name(),
+                        forkJoinPool.submit(() -> modified)));
             } else if (entry.name().endsWith(".class")) {
                 ForkJoinTask<byte[]> task = forkJoinPool.submit(
                         () -> transformClass(entry.name(), entry.content()));
                 prepared.add(new PreparedEntry(entry.name(), task));
             } else {
                 prepared.add(new PreparedEntry(entry.name(),
-                        ForkJoinTask.adapt(entry::content)));
+                        forkJoinPool.submit(entry::content)));
             }
         }
         return prepared;


### PR DESCRIPTION
## 概要

v2.0 系を発展させるため、変換パイプラインの並列タスク処理を安定化し、リリース CD と依存関係更新を自動化します。

## 変更内容

- `PluginPatcher` の非 class / `plugin.yml` 用タスクを専用 `ForkJoinPool` に確実に submit
  - 未スケジュールの `ForkJoinTask` を `join()` する可能性を排除
  - class 変換と同一の実行・完了モデルに統一
- タグ `v*` を契機とする Release workflow を追加
  - Java 21 で `clean verify`
  - 全成果物を収集
  - SHA-256 チェックサム生成
  - Actions artifact 保存
  - GitHub Release 自動作成
- Dependabot を追加
  - Maven 依存関係
  - GitHub Actions
  - minor/patch 更新をグルーピング

## 補足

`develop` 側には作業中に先行更新が入り、初期の性能改善と CI 本体は既にベースへ取り込まれています。この PR は競合を避け、残差の安定化と CD 強化に限定しています。