### PR TITLE
feat: release minimal CheerpJ web version

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: '21'
           cache: maven
           cache-dependency-path: folia-phantom/pom.xml
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,56 @@
+name: Pages
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+          cache-dependency-path: folia-phantom/pom.xml
+
+      - name: Build web JAR
+        working-directory: folia-phantom
+        run: mvn --batch-mode --no-transfer-progress -pl folia-phantom-web -am package
+
+      - name: Assemble static site
+        run: cp folia-phantom/folia-phantom-web/target/pasta-web.jar web/pasta-web.jar
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: web
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/folia-phantom/folia-phantom-web/pom.xml
+++ b/folia-phantom/folia-phantom-web/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.patch</groupId>
+        <artifactId>folia-phantom</artifactId>
+        <version>2.0.0</version>
+    </parent>
+
+    <artifactId>folia-phantom-web</artifactId>
+    <name>pasta-web</name>
+    <description>CheerpJ bridge for the static web version</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.patch</groupId>
+            <artifactId>folia-phantom-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-nop</artifactId>
+            <version>2.0.9</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>pasta-web</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/folia-phantom/folia-phantom-web/src/main/java/com/patch/foliaphantom/web/WebPatcher.java
+++ b/folia-phantom/folia-phantom-web/src/main/java/com/patch/foliaphantom/web/WebPatcher.java
@@ -1,0 +1,15 @@
+package com.patch.foliaphantom.web;
+
+import com.patch.foliaphantom.patcher.PluginPatcher;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/** Minimal CheerpJ entry point used by the static web UI. */
+public final class WebPatcher {
+
+    public void patch(String inputPath) throws IOException {
+        PluginPatcher patcher = new PluginPatcher(Path.of("/files"), false);
+        patcher.patchPlugin(Path.of(inputPath));
+    }
+}

--- a/folia-phantom/pom.xml
+++ b/folia-phantom/pom.xml
@@ -21,6 +21,7 @@
         <module>folia-phantom-cli</module>
         <module>folia-phantom-gui</module>
         <module>folia-phantom-plugin</module>
+        <module>folia-phantom-web</module>
     </modules>
 
     <properties>

--- a/web/app.js
+++ b/web/app.js
@@ -6,9 +6,16 @@ let patcherPromise;
 
 fileInput.addEventListener("change", () => {
   const file = fileInput.files?.[0];
-  const valid = Boolean(file && file.name.toLowerCase().endsWith(".jar"));
+  const isJar = Boolean(file && file.name.toLowerCase().endsWith(".jar"));
+  const alreadyPatched = Boolean(file && file.name.toLowerCase().startsWith("patched-"));
+  const valid = isJar && !alreadyPatched;
+
   patchButton.disabled = !valid;
-  status.textContent = valid ? file.name : "Select a .jar file.";
+  status.textContent = alreadyPatched
+    ? "Already patched."
+    : valid
+      ? file.name
+      : "Select a .jar file.";
 });
 
 patchButton.addEventListener("click", async () => {

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,86 @@
+const fileInput = document.getElementById("file");
+const patchButton = document.getElementById("patch");
+const status = document.getElementById("status");
+
+let patcherPromise;
+
+fileInput.addEventListener("change", () => {
+  const file = fileInput.files?.[0];
+  const valid = Boolean(file && file.name.toLowerCase().endsWith(".jar"));
+  patchButton.disabled = !valid;
+  status.textContent = valid ? file.name : "Select a .jar file.";
+});
+
+patchButton.addEventListener("click", async () => {
+  const file = fileInput.files?.[0];
+  if (!file) return;
+
+  patchButton.disabled = true;
+  const safeName = sanitizeFileName(file.name);
+  const inputPath = `/str/${safeName}`;
+  const outputPath = `/files/patched-${safeName}`;
+
+  try {
+    status.textContent = "Loading Java…";
+    const patcher = await getPatcher();
+
+    status.textContent = "Patching…";
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    cheerpOSAddStringFile(inputPath, bytes);
+
+    await patcher.patch(inputPath);
+
+    status.textContent = "Downloading…";
+    const blob = await cjFileBlob(outputPath);
+    downloadBlob(blob, `patched-${file.name}`);
+    status.textContent = "Done.";
+  } catch (error) {
+    console.error(error);
+    status.textContent = `Error: ${await errorMessage(error)}`;
+  } finally {
+    cheerpOSRemoveStringFile(inputPath);
+    patchButton.disabled = false;
+  }
+});
+
+async function getPatcher() {
+  if (!patcherPromise) {
+    patcherPromise = (async () => {
+      await cheerpjInit({ version: 17, status: "none" });
+
+      const jarUrl = new URL("./pasta-web.jar", window.location.href);
+      const libraryPath = `/app${jarUrl.pathname}`;
+      const library = await cheerpjRunLibrary(libraryPath);
+      const WebPatcher = await library.com.patch.foliaphantom.web.WebPatcher;
+      return await new WebPatcher();
+    })();
+  }
+  return patcherPromise;
+}
+
+function sanitizeFileName(name) {
+  const sanitized = name.replace(/[^a-zA-Z0-9._-]/g, "_");
+  return sanitized || "plugin.jar";
+}
+
+function downloadBlob(blob, fileName) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+async function errorMessage(error) {
+  try {
+    if (typeof error?.getMessage === "function") {
+      return (await error.getMessage()) || String(error);
+    }
+  } catch {
+    // Fall back to the JavaScript representation.
+  }
+  return error?.message || String(error);
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>pasta</title>
+  <meta name="description" content="Patch Bukkit plugins for Folia in your browser.">
+  <script src="https://cjrtnc.leaningtech.com/4.3/loader.js"></script>
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      padding: 24px;
+      font: 15px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      color: #111;
+      background: #fff;
+    }
+    main { width: min(100%, 520px); }
+    h1 { margin: 0 0 8px; font-size: 28px; }
+    p { margin: 0 0 24px; color: #666; }
+    input { width: 100%; margin-bottom: 12px; }
+    button {
+      width: 100%;
+      padding: 12px 16px;
+      border: 1px solid #111;
+      border-radius: 6px;
+      background: #111;
+      color: #fff;
+      font: inherit;
+      cursor: pointer;
+    }
+    button:disabled { opacity: .45; cursor: default; }
+    #status { min-height: 24px; margin: 14px 0 0; color: #666; }
+    footer { margin-top: 28px; font-size: 12px; color: #888; }
+    a { color: inherit; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>pasta</h1>
+    <p>Bukkit plugin → Folia</p>
+
+    <input id="file" type="file" accept=".jar,application/java-archive">
+    <button id="patch" disabled>Patch &amp; Download</button>
+    <div id="status">Select a .jar file.</div>
+
+    <footer>
+      Runs locally in your browser with CheerpJ. Your plugin JAR is not uploaded to pasta.
+    </footer>
+  </main>
+
+  <script type="module" src="./app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a minimal static UI for GitHub Pages
- run the existing patch engine in-browser via CheerpJ 4.3 / Java 17
- add a small `folia-phantom-web` bridge module and shaded JAR
- deploy `web/` with the generated JAR through GitHub Pages Actions

## UX
1. Select a Bukkit plugin `.jar`
2. Click **Patch & Download**
3. The transformed `patched-*.jar` is generated in the browser and downloaded

The input JAR is passed into CheerpJ's browser-side virtual filesystem; pasta does not upload it to an application backend.

## Deploy
After merging to `develop`, enable **Settings → Pages → Source: GitHub Actions** once if Pages is not already enabled. The `Pages` workflow then builds the shaded web JAR with JDK 21 and deploys the static `web/` directory.

## Verification
- Java 21 reactor build: passes, including `pasta-web`
- Java 17 reactor build: fails in the existing core because Paper API 1.21.1 contains Java 21 class files (`65.0` vs `61.0`); Pages build therefore uses JDK 21