### PR TITLE
chore: relicense pasta under MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 MARVserver
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -141,4 +141,4 @@ JarOutputStream ──► Patched JAR
 
 ## License
 
-MARV License v1.0.0
+MIT License. See [LICENSE](LICENSE).

--- a/folia-phantom/pom.xml
+++ b/folia-phantom/pom.xml
@@ -16,6 +16,14 @@
     <name>pasta</name>
     <description>Folia Phantom — Bukkit to Folia bytecode transformer</description>
 
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>https://opensource.org/license/mit</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
     <modules>
         <module>folia-phantom-core</module>
         <module>folia-phantom-cli</module>


### PR DESCRIPTION
## Summary
- add the standard MIT License at repository root
- update README license section from MARV License v1.0.0 to MIT
- declare MIT in Maven project metadata

Copyright holder is `MARVserver` (2026).

Third-party dependencies and CheerpJ retain their own licenses; this change applies to the pasta project code.