### PR TITLE
feat: add web batch patching and reports

### DIFF
--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/PluginPatcher.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/PluginPatcher.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinTask;
 import java.util.concurrent.TimeUnit;
@@ -59,6 +60,7 @@ public final class PluginPatcher {
     private final boolean verbose;
     private final AtomicInteger patchedClassCount = new AtomicInteger();
     private final AtomicInteger skippedClassCount = new AtomicInteger();
+    private final ConcurrentLinkedQueue<String> patchedClassNames = new ConcurrentLinkedQueue<>();
 
     public PluginPatcher(Path outputDir, boolean verbose) {
         this.outputDir = outputDir;
@@ -84,6 +86,7 @@ public final class PluginPatcher {
         long startedAt = System.nanoTime();
         patchedClassCount.set(0);
         skippedClassCount.set(0);
+        patchedClassNames.clear();
         Files.createDirectories(outputDir);
         Path outputPath = outputDir.resolve("patched-" + fileName);
         log.info("Patching plugin: {} with {} worker(s)", fileName, forkJoinPool.getParallelism());
@@ -157,7 +160,7 @@ public final class PluginPatcher {
 
         byte[] result = classBytes;
         for (ClassTransformer transformer : transformers) {
-            ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+            ClassWriter writer = new SafeClassWriter(ClassWriter.COMPUTE_FRAMES);
             byte[] transformed = transformer.transform(classNode, className, writer);
             if (transformed != null) {
                 result = transformed;
@@ -168,6 +171,7 @@ public final class PluginPatcher {
         }
 
         patchedClassCount.incrementAndGet();
+        patchedClassNames.add(className);
         if (verbose) {
             log.debug("Patched class: {}", className);
         }
@@ -250,6 +254,32 @@ public final class PluginPatcher {
 
     public int getSkippedClassCount() {
         return skippedClassCount.get();
+    }
+
+    public List<String> getPatchedClassNames() {
+        return patchedClassNames.stream().sorted().toList();
+    }
+
+    /**
+     * ASM normally loads referenced classes while computing stack map frames. Plugin dependencies
+     * such as Bukkit/Paper are intentionally absent from the CLI and browser runtime, so fall back
+     * to Object when an external type cannot be resolved. Resolvable JDK/application types still use
+     * ASM's normal hierarchy calculation.
+     */
+    private static final class SafeClassWriter extends ClassWriter {
+
+        private SafeClassWriter(int flags) {
+            super(flags);
+        }
+
+        @Override
+        protected String getCommonSuperClass(String type1, String type2) {
+            try {
+                return super.getCommonSuperClass(type1, type2);
+            } catch (TypeNotPresentException | LinkageError exception) {
+                return "java/lang/Object";
+            }
+        }
     }
 
     private record PreparedEntry(

--- a/folia-phantom/folia-phantom-web/src/main/java/com/patch/foliaphantom/web/WebPatcher.java
+++ b/folia-phantom/folia-phantom-web/src/main/java/com/patch/foliaphantom/web/WebPatcher.java
@@ -3,13 +3,33 @@ package com.patch.foliaphantom.web;
 import com.patch.foliaphantom.patcher.PluginPatcher;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 /** Minimal CheerpJ entry point used by the static web UI. */
 public final class WebPatcher {
 
-    public void patch(String inputPath) throws IOException {
+    /**
+     * Patches one plugin and returns a compact text report.
+     * First line: patched-class count, tab, skipped-class count.
+     * Remaining lines: fully qualified names of patched classes.
+     */
+    public String patch(String inputPath) throws IOException {
         PluginPatcher patcher = new PluginPatcher(Path.of("/files"), false);
         patcher.patchPlugin(Path.of(inputPath));
+
+        StringBuilder report = new StringBuilder()
+                .append(patcher.getPatchedClassCount())
+                .append('\t')
+                .append(patcher.getSkippedClassCount());
+        for (String className : patcher.getPatchedClassNames()) {
+            report.append('\n').append(className);
+        }
+        return report.toString();
+    }
+
+    /** Removes a temporary output after JavaScript has copied it into a browser Blob. */
+    public void delete(String path) throws IOException {
+        Files.deleteIfExists(Path.of(path));
     }
 }

--- a/web/app.js
+++ b/web/app.js
@@ -1,52 +1,145 @@
 const fileInput = document.getElementById("file");
 const patchButton = document.getElementById("patch");
 const status = document.getElementById("status");
+const reportSection = document.getElementById("report");
+const reportSummary = document.getElementById("report-summary");
+const resultsContainer = document.getElementById("results");
+const reportDownload = document.getElementById("report-download");
 
 let patcherPromise;
+let objectUrls = [];
+
+reportDownload.hidden = true;
 
 fileInput.addEventListener("change", () => {
-  const file = fileInput.files?.[0];
-  const isJar = Boolean(file && file.name.toLowerCase().endsWith(".jar"));
-  const alreadyPatched = Boolean(file && file.name.toLowerCase().startsWith("patched-"));
-  const valid = isJar && !alreadyPatched;
+  clearReport();
 
-  patchButton.disabled = !valid;
-  status.textContent = alreadyPatched
-    ? "Already patched."
-    : valid
-      ? file.name
-      : "Select a .jar file.";
+  const files = selectedFiles();
+  const patchable = files.filter(isPatchableJar);
+  const ignored = files.length - patchable.length;
+
+  patchButton.disabled = patchable.length === 0;
+
+  if (files.length === 0) {
+    status.textContent = "Select one or more .jar files.";
+  } else if (ignored > 0) {
+    status.textContent = `${patchable.length} ready, ${ignored} ignored.`;
+  } else {
+    status.textContent = `${patchable.length} file${patchable.length === 1 ? "" : "s"} ready.`;
+  }
 });
 
 patchButton.addEventListener("click", async () => {
-  const file = fileInput.files?.[0];
-  if (!file) return;
+  const files = selectedFiles();
+  const patchableCount = files.filter(isPatchableJar).length;
+  if (patchableCount === 0) return;
 
+  clearReport();
   patchButton.disabled = true;
-  const safeName = sanitizeFileName(file.name);
-  const inputPath = `/str/${safeName}`;
-  const outputPath = `/files/patched-${safeName}`;
+  fileInput.disabled = true;
+
+  const results = [];
+  let currentPatchable = 0;
 
   try {
     status.textContent = "Loading Java…";
     const patcher = await getPatcher();
 
-    status.textContent = "Patching…";
-    const bytes = new Uint8Array(await file.arrayBuffer());
-    cheerpOSAddStringFile(inputPath, bytes);
+    for (let index = 0; index < files.length; index++) {
+      const file = files[index];
 
-    await patcher.patch(inputPath);
+      if (!isJar(file)) {
+        results.push({
+          file: file.name,
+          status: "skipped",
+          patched: 0,
+          skipped: 0,
+          classes: [],
+          error: "Not a .jar file."
+        });
+        renderReport(results, files.length);
+        continue;
+      }
 
-    status.textContent = "Downloading…";
-    const blob = await cjFileBlob(outputPath);
-    downloadBlob(blob, `patched-${file.name}`);
-    status.textContent = "Done.";
+      if (isAlreadyPatched(file)) {
+        results.push({
+          file: file.name,
+          status: "skipped",
+          patched: 0,
+          skipped: 0,
+          classes: [],
+          error: "Already patched."
+        });
+        renderReport(results, files.length);
+        continue;
+      }
+
+      currentPatchable += 1;
+      status.textContent = `Patching ${currentPatchable}/${patchableCount}: ${file.name}`;
+
+      const safeName = `input-${index}-${sanitizeFileName(file.name)}`;
+      const inputPath = `/str/${safeName}`;
+      const outputPath = `/files/patched-${safeName}`;
+
+      try {
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        cheerpOSAddStringFile(inputPath, bytes);
+
+        const rawReport = await patcher.patch(inputPath);
+        const parsed = parsePatchReport(String(rawReport));
+        const blob = await cjFileBlob(outputPath);
+        const downloadUrl = URL.createObjectURL(blob);
+        objectUrls.push(downloadUrl);
+
+        results.push({
+          file: file.name,
+          status: "success",
+          patched: parsed.patched,
+          skipped: parsed.skipped,
+          classes: parsed.classes,
+          error: "",
+          downloadUrl,
+          downloadName: `patched-${file.name}`
+        });
+
+        try {
+          await patcher.delete(outputPath);
+        } catch (cleanupError) {
+          console.warn("Could not remove temporary output", cleanupError);
+        }
+      } catch (error) {
+        console.error(error);
+        results.push({
+          file: file.name,
+          status: "failed",
+          patched: 0,
+          skipped: 0,
+          classes: [],
+          error: await errorMessage(error)
+        });
+      } finally {
+        cheerpOSRemoveStringFile(inputPath);
+      }
+
+      renderReport(results, files.length);
+    }
+
+    const succeeded = results.filter(result => result.status === "success").length;
+    const failed = results.filter(result => result.status === "failed").length;
+    const skipped = results.filter(result => result.status === "skipped").length;
+    status.textContent = `Done. ${succeeded} succeeded, ${failed} failed, ${skipped} skipped.`;
+    updateReportDownload(results);
+
+    if (succeeded === 1 && patchableCount === 1) {
+      const result = results.find(item => item.status === "success");
+      if (result) downloadUrl(result.downloadUrl, result.downloadName);
+    }
   } catch (error) {
     console.error(error);
     status.textContent = `Error: ${await errorMessage(error)}`;
   } finally {
-    cheerpOSRemoveStringFile(inputPath);
-    patchButton.disabled = false;
+    fileInput.disabled = false;
+    patchButton.disabled = selectedFiles().filter(isPatchableJar).length === 0;
   }
 });
 
@@ -60,9 +153,28 @@ async function getPatcher() {
       const library = await cheerpjRunLibrary(libraryPath);
       const WebPatcher = await library.com.patch.foliaphantom.web.WebPatcher;
       return await new WebPatcher();
-    })();
+    })().catch(error => {
+      patcherPromise = undefined;
+      throw error;
+    });
   }
   return patcherPromise;
+}
+
+function selectedFiles() {
+  return Array.from(fileInput.files ?? []);
+}
+
+function isJar(file) {
+  return file.name.toLowerCase().endsWith(".jar");
+}
+
+function isAlreadyPatched(file) {
+  return file.name.toLowerCase().startsWith("patched-");
+}
+
+function isPatchableJar(file) {
+  return isJar(file) && !isAlreadyPatched(file);
 }
 
 function sanitizeFileName(name) {
@@ -70,24 +182,181 @@ function sanitizeFileName(name) {
   return sanitized || "plugin.jar";
 }
 
-function downloadBlob(blob, fileName) {
+function parsePatchReport(text) {
+  const lines = text.split("\n");
+  const [patchedText = "0", skippedText = "0"] = (lines.shift() ?? "").split("\t");
+  return {
+    patched: Number.parseInt(patchedText, 10) || 0,
+    skipped: Number.parseInt(skippedText, 10) || 0,
+    classes: lines.filter(Boolean)
+  };
+}
+
+function renderReport(results, total) {
+  reportSection.hidden = false;
+  resultsContainer.replaceChildren(...results.map(createResultElement));
+
+  const succeeded = results.filter(result => result.status === "success").length;
+  const failed = results.filter(result => result.status === "failed").length;
+  const skipped = results.filter(result => result.status === "skipped").length;
+  reportSummary.textContent = `${results.length}/${total} processed · ${succeeded} success · ${failed} failed · ${skipped} skipped`;
+}
+
+function createResultElement(result) {
+  const article = document.createElement("article");
+  article.className = "result";
+
+  const head = document.createElement("div");
+  head.className = "result-head";
+
+  const name = document.createElement("strong");
+  name.className = "result-name";
+  name.textContent = result.file;
+
+  const meta = document.createElement("span");
+  meta.className = "result-meta";
+  meta.textContent = result.status === "success"
+    ? `${result.patched} patched / ${result.skipped} skipped`
+    : result.status;
+
+  head.append(name, meta);
+  article.append(head);
+
+  if (result.error) {
+    const error = document.createElement("div");
+    error.className = "result-error";
+    error.textContent = result.error;
+    article.append(error);
+  }
+
+  if (result.status === "success") {
+    const links = document.createElement("div");
+    links.className = "links";
+
+    const download = document.createElement("a");
+    download.href = result.downloadUrl;
+    download.download = result.downloadName;
+    download.textContent = "Download JAR";
+    links.append(download);
+    article.append(links);
+
+    if (result.classes.length > 0) {
+      const details = document.createElement("details");
+      const summary = document.createElement("summary");
+      summary.textContent = `${result.classes.length} patched classes`;
+      const pre = document.createElement("pre");
+      pre.textContent = result.classes.join("\n");
+      details.append(summary, pre);
+      article.append(details);
+    }
+  }
+
+  return article;
+}
+
+function updateReportDownload(results) {
+  const rows = [
+    ["file", "status", "patched_classes", "skipped_classes", "patched_class_names", "error"],
+    ...results.map(result => [
+      result.file,
+      result.status,
+      result.patched,
+      result.skipped,
+      result.classes.join(";"),
+      result.error
+    ])
+  ];
+
+  const csv = rows.map(row => row.map(csvCell).join(",")).join("\r\n");
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
   const url = URL.createObjectURL(blob);
+  objectUrls.push(url);
+  reportDownload.href = url;
+  reportDownload.hidden = false;
+}
+
+function csvCell(value) {
+  const text = String(value ?? "");
+  return `"${text.replaceAll('"', '""')}"`;
+}
+
+function downloadUrl(url, fileName) {
   const link = document.createElement("a");
   link.href = url;
   link.download = fileName;
   document.body.appendChild(link);
   link.click();
   link.remove();
-  URL.revokeObjectURL(url);
+}
+
+function clearReport() {
+  for (const url of objectUrls) URL.revokeObjectURL(url);
+  objectUrls = [];
+  resultsContainer.replaceChildren();
+  reportSummary.textContent = "";
+  reportDownload.removeAttribute("href");
+  reportDownload.hidden = true;
+  reportSection.hidden = true;
 }
 
 async function errorMessage(error) {
+  const parts = [];
+  let current = error;
+
+  for (let depth = 0; depth < 4 && current; depth++) {
+    const name = await throwableName(current);
+    const message = await throwableMessage(current);
+    const typeName = await missingTypeName(current);
+    const detail = message || typeName;
+    const part = [name, detail].filter(Boolean).join(": ");
+    if (part && !parts.includes(part)) parts.push(part);
+
+    try {
+      current = typeof current?.getCause === "function"
+        ? await current.getCause()
+        : null;
+    } catch {
+      current = null;
+    }
+  }
+
+  return parts.join(" → ") || error?.message || String(error);
+}
+
+async function throwableName(error) {
   try {
-    if (typeof error?.getMessage === "function") {
-      return (await error.getMessage()) || String(error);
+    if (typeof error?.getClass === "function") {
+      const clazz = await error.getClass();
+      if (clazz && typeof clazz.getName === "function") {
+        return String(await clazz.getName());
+      }
     }
   } catch {
-    // Fall back to the JavaScript representation.
+    // Fall through to the JavaScript name.
   }
-  return error?.message || String(error);
+  return error?.name || "";
+}
+
+async function throwableMessage(error) {
+  try {
+    if (typeof error?.getMessage === "function") {
+      const message = await error.getMessage();
+      if (message) return String(message);
+    }
+  } catch {
+    // Fall through to the JavaScript message.
+  }
+  return error?.message || "";
+}
+
+async function missingTypeName(error) {
+  try {
+    if (typeof error?.typeName === "function") {
+      const value = await error.typeName();
+      return value ? `missing type ${String(value)}` : "";
+    }
+  } catch {
+    // Not a TypeNotPresentException.
+  }
+  return "";
 }

--- a/web/index.html
+++ b/web/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>pasta</title>
   <meta name="description" content="Patch Bukkit plugins for Folia in your browser.">
+  <link rel="icon" href="data:,">
   <script src="https://cjrtnc.leaningtech.com/4.3/loader.js"></script>
   <style>
     * { box-sizing: border-box; }
@@ -18,7 +19,7 @@
       color: #111;
       background: #fff;
     }
-    main { width: min(100%, 520px); }
+    main { width: min(100%, 720px); }
     h1 { margin: 0 0 8px; font-size: 28px; }
     p { margin: 0 0 24px; color: #666; }
     input { width: 100%; margin-bottom: 12px; }
@@ -34,6 +35,28 @@
     }
     button:disabled { opacity: .45; cursor: default; }
     #status { min-height: 24px; margin: 14px 0 0; color: #666; }
+    #report { margin-top: 24px; }
+    #report[hidden] { display: none; }
+    .summary { margin-bottom: 12px; color: #444; }
+    .result {
+      padding: 12px 0;
+      border-top: 1px solid #ddd;
+    }
+    .result:last-of-type { border-bottom: 1px solid #ddd; }
+    .result-head {
+      display: flex;
+      gap: 12px;
+      justify-content: space-between;
+      align-items: baseline;
+    }
+    .result-name { overflow-wrap: anywhere; }
+    .result-meta { color: #666; white-space: nowrap; }
+    .result-error { margin-top: 6px; color: #900; overflow-wrap: anywhere; }
+    .links { display: flex; gap: 14px; margin-top: 8px; }
+    .links a, #report-download { color: inherit; }
+    details { margin-top: 8px; color: #555; }
+    pre { margin: 8px 0 0; white-space: pre-wrap; overflow-wrap: anywhere; font: inherit; }
+    #report-download { display: inline-block; margin-top: 14px; }
     footer { margin-top: 28px; font-size: 12px; color: #888; }
     a { color: inherit; }
   </style>
@@ -43,12 +66,18 @@
     <h1>pasta</h1>
     <p>Bukkit plugin → Folia</p>
 
-    <input id="file" type="file" accept=".jar,application/java-archive">
-    <button id="patch" disabled>Patch &amp; Download</button>
-    <div id="status">Select a .jar file.</div>
+    <input id="file" type="file" multiple accept=".jar,application/java-archive">
+    <button id="patch" disabled>Patch selected</button>
+    <div id="status">Select one or more .jar files.</div>
+
+    <section id="report" hidden aria-live="polite">
+      <div id="report-summary" class="summary"></div>
+      <div id="results"></div>
+      <a id="report-download" download="pasta-report.csv">Download report.csv</a>
+    </section>
 
     <footer>
-      Runs locally in your browser with CheerpJ. Your plugin JAR is not uploaded to pasta.
+      Runs locally in your browser with CheerpJ. Your plugin JARs are not uploaded to pasta.
     </footer>
   </main>
 


### PR DESCRIPTION
## Summary
- allow selecting and patching multiple plugin JARs in the GitHub Pages UI
- show per-JAR success/failure/skipped status, patched/skipped class counts, and patched class names
- provide individual output JAR download links plus a downloadable CSV report
- keep single-file behavior convenient by auto-downloading when exactly one patch succeeds
- fix `TypeNotPresentException` from ASM frame computation when Bukkit/Paper classes are absent in the browser runtime
- suppress the irrelevant favicon 404

## CheerpJ compatibility
CheerpJ 4.3 supports Java 8/11/17, not Java 21. The web runtime remains Java 17. The failure reported in the browser was caused by ASM attempting to resolve external Bukkit/Paper types while computing frames, not by the page's browser-extension `contentscript.js` warnings.

The new `SafeClassWriter` uses ASM's normal hierarchy calculation when types are resolvable and falls back to `java/lang/Object` only when an external type cannot be loaded.

## UX
1. Select one or more `.jar` files
2. Click **Patch selected**
3. Each result shows counts and patched classes
4. Download each successful patched JAR
5. Optionally download `pasta-report.csv`
