### PR TITLE
fix: harden CheerpJ class transforms

### DIFF
--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/PluginPatcher.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/patcher/PluginPatcher.java
@@ -58,16 +58,29 @@ public final class PluginPatcher {
     private final ForkJoinPool forkJoinPool;
     private final Path outputDir;
     private final boolean verbose;
+    private final boolean parallel;
     private final AtomicInteger patchedClassCount = new AtomicInteger();
     private final AtomicInteger skippedClassCount = new AtomicInteger();
+    private final AtomicInteger failedClassCount = new AtomicInteger();
     private final ConcurrentLinkedQueue<String> patchedClassNames = new ConcurrentLinkedQueue<>();
+    private final ConcurrentLinkedQueue<TransformationFailure> transformationFailures =
+            new ConcurrentLinkedQueue<>();
 
     public PluginPatcher(Path outputDir, boolean verbose) {
+        this(outputDir, verbose, true);
+    }
+
+    /**
+     * @param parallel whether class transformations should use a ForkJoinPool. Browser runtimes can
+     *                 disable this to avoid worker/thread emulation overhead and improve stability.
+     */
+    public PluginPatcher(Path outputDir, boolean verbose, boolean parallel) {
         this.outputDir = outputDir;
         this.verbose = verbose;
+        this.parallel = parallel;
         int processors = Runtime.getRuntime().availableProcessors();
         int parallelism = Math.max(1, processors > 2 ? processors - 1 : processors);
-        this.forkJoinPool = new ForkJoinPool(parallelism);
+        this.forkJoinPool = parallel ? new ForkJoinPool(parallelism) : null;
         this.transformers = List.of(
                 new ThreadSafetyTransformer(),
                 new WorldGenClassTransformer(),
@@ -86,10 +99,13 @@ public final class PluginPatcher {
         long startedAt = System.nanoTime();
         patchedClassCount.set(0);
         skippedClassCount.set(0);
+        failedClassCount.set(0);
         patchedClassNames.clear();
+        transformationFailures.clear();
         Files.createDirectories(outputDir);
         Path outputPath = outputDir.resolve("patched-" + fileName);
-        log.info("Patching plugin: {} with {} worker(s)", fileName, forkJoinPool.getParallelism());
+        int workers = parallel ? forkJoinPool.getParallelism() : 1;
+        log.info("Patching plugin: {} with {} worker(s)", fileName, workers);
 
         List<PreparedEntry> prepared = readAndPrepareEntries(jarPath);
 
@@ -111,8 +127,8 @@ public final class PluginPatcher {
         }
 
         long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt);
-        log.info("Patch complete for: {} (patched: {}, skipped: {}, elapsed: {} ms)",
-                fileName, patchedClassCount.get(), skippedClassCount.get(), elapsedMs);
+        log.info("Patch complete for: {} (patched: {}, skipped: {}, unchanged after errors: {}, elapsed: {} ms)",
+                fileName, patchedClassCount.get(), skippedClassCount.get(), failedClassCount.get(), elapsedMs);
         return outputPath;
     }
 
@@ -130,9 +146,13 @@ public final class PluginPatcher {
                 if ("plugin.yml".equals(name)) {
                     entries.add(PreparedEntry.direct(name, modifyPluginYml(content)));
                 } else if (name.endsWith(".class")) {
-                    ForkJoinTask<byte[]> task = forkJoinPool.submit(
-                            () -> transformClass(name, content));
-                    entries.add(PreparedEntry.async(name, task));
+                    if (parallel) {
+                        ForkJoinTask<byte[]> task = forkJoinPool.submit(
+                                () -> transformClass(name, content));
+                        entries.add(PreparedEntry.async(name, task));
+                    } else {
+                        entries.add(PreparedEntry.direct(name, transformClass(name, content)));
+                    }
                 } else {
                     entries.add(PreparedEntry.direct(name, content));
                 }
@@ -145,37 +165,48 @@ public final class PluginPatcher {
         String className = entryName.substring(0, entryName.length() - ".class".length())
                 .replace('/', '.');
 
-        // Most library classes do not reference Bukkit at all. Avoid constructing ASM visitors for them.
-        if (!containsBytes(classBytes, BUKKIT_CONSTANT_POOL_MARKER) || !needsPatching(classBytes)) {
-            skippedClassCount.incrementAndGet();
-            if (verbose) {
-                log.debug("Skipping class (no patch needed): {}", className);
+        try {
+            // Most library classes do not reference Bukkit at all. Avoid constructing ASM visitors for them.
+            if (!containsBytes(classBytes, BUKKIT_CONSTANT_POOL_MARKER) || !needsPatching(classBytes)) {
+                skippedClassCount.incrementAndGet();
+                if (verbose) {
+                    log.debug("Skipping class (no patch needed): {}", className);
+                }
+                return classBytes;
             }
+
+            ClassReader reader = new ClassReader(classBytes);
+            ClassNode classNode = new ClassNode(ASM_API);
+            reader.accept(classNode, ClassReader.EXPAND_FRAMES);
+
+            byte[] result = classBytes;
+            for (ClassTransformer transformer : transformers) {
+                ClassWriter writer = new SafeClassWriter(ClassWriter.COMPUTE_FRAMES);
+                byte[] transformed = transformer.transform(classNode, className, writer);
+                if (transformed != null) {
+                    result = transformed;
+                    reader = new ClassReader(result);
+                    classNode = new ClassNode(ASM_API);
+                    reader.accept(classNode, ClassReader.EXPAND_FRAMES);
+                }
+            }
+
+            patchedClassCount.incrementAndGet();
+            patchedClassNames.add(className);
+            if (verbose) {
+                log.debug("Patched class: {}", className);
+            }
+            return result;
+        } catch (RuntimeException | LinkageError exception) {
+            failedClassCount.incrementAndGet();
+            transformationFailures.add(new TransformationFailure(
+                    className,
+                    exception.getClass().getName(),
+                    exception.getMessage() == null ? "" : exception.getMessage()));
+            log.warn("Leaving class unmodified after transform failure: {} ({})",
+                    className, exception.toString());
             return classBytes;
         }
-
-        ClassReader reader = new ClassReader(classBytes);
-        ClassNode classNode = new ClassNode(ASM_API);
-        reader.accept(classNode, ClassReader.EXPAND_FRAMES);
-
-        byte[] result = classBytes;
-        for (ClassTransformer transformer : transformers) {
-            ClassWriter writer = new SafeClassWriter(ClassWriter.COMPUTE_FRAMES);
-            byte[] transformed = transformer.transform(classNode, className, writer);
-            if (transformed != null) {
-                result = transformed;
-                reader = new ClassReader(result);
-                classNode = new ClassNode(ASM_API);
-                reader.accept(classNode, ClassReader.EXPAND_FRAMES);
-            }
-        }
-
-        patchedClassCount.incrementAndGet();
-        patchedClassNames.add(className);
-        if (verbose) {
-            log.debug("Patched class: {}", className);
-        }
-        return result;
     }
 
     private boolean needsPatching(byte[] classBytes) {
@@ -256,8 +287,18 @@ public final class PluginPatcher {
         return skippedClassCount.get();
     }
 
+    public int getFailedClassCount() {
+        return failedClassCount.get();
+    }
+
     public List<String> getPatchedClassNames() {
         return patchedClassNames.stream().sorted().toList();
+    }
+
+    public List<TransformationFailure> getTransformationFailures() {
+        return transformationFailures.stream()
+                .sorted(java.util.Comparator.comparing(TransformationFailure::className))
+                .toList();
     }
 
     /**
@@ -280,6 +321,9 @@ public final class PluginPatcher {
                 return "java/lang/Object";
             }
         }
+    }
+
+    public record TransformationFailure(String className, String exceptionType, String message) {
     }
 
     private record PreparedEntry(

--- a/folia-phantom/folia-phantom-web/src/main/java/com/patch/foliaphantom/web/WebPatcher.java
+++ b/folia-phantom/folia-phantom-web/src/main/java/com/patch/foliaphantom/web/WebPatcher.java
@@ -10,20 +10,32 @@ import java.nio.file.Path;
 public final class WebPatcher {
 
     /**
-     * Patches one plugin and returns a compact text report.
-     * First line: patched-class count, tab, skipped-class count.
-     * Remaining lines: fully qualified names of patched classes.
+     * Patches one plugin and returns a compact tab-separated report.
+     * Header: patched count, skipped count, unchanged-after-error count.
+     * P-lines contain patched classes. F-lines contain classes that were left unchanged.
      */
     public String patch(String inputPath) throws IOException {
-        PluginPatcher patcher = new PluginPatcher(Path.of("/files"), false);
+        // CheerpJ does not benefit from the desktop ForkJoinPool here. Keep ASM work sequential so
+        // one browser task owns the mutable class tree at a time and worker emulation cannot leak.
+        PluginPatcher patcher = new PluginPatcher(Path.of("/files"), false, false);
         patcher.patchPlugin(Path.of(inputPath));
 
         StringBuilder report = new StringBuilder()
                 .append(patcher.getPatchedClassCount())
                 .append('\t')
-                .append(patcher.getSkippedClassCount());
+                .append(patcher.getSkippedClassCount())
+                .append('\t')
+                .append(patcher.getFailedClassCount());
+
         for (String className : patcher.getPatchedClassNames()) {
-            report.append('\n').append(className);
+            report.append('\n').append("P\t").append(cleanField(className));
+        }
+        for (PluginPatcher.TransformationFailure failure : patcher.getTransformationFailures()) {
+            report.append('\n')
+                    .append("F\t")
+                    .append(cleanField(failure.className())).append('\t')
+                    .append(cleanField(failure.exceptionType())).append('\t')
+                    .append(cleanField(failure.message()));
         }
         return report.toString();
     }
@@ -31,5 +43,12 @@ public final class WebPatcher {
     /** Removes a temporary output after JavaScript has copied it into a browser Blob. */
     public void delete(String path) throws IOException {
         Files.deleteIfExists(Path.of(path));
+    }
+
+    private static String cleanField(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replace('\t', ' ').replace('\r', ' ').replace('\n', ' ');
     }
 }

--- a/web/app.js
+++ b/web/app.js
@@ -49,27 +49,13 @@ patchButton.addEventListener("click", async () => {
       const file = files[index];
 
       if (!isJar(file)) {
-        results.push({
-          file: file.name,
-          status: "skipped",
-          patched: 0,
-          skipped: 0,
-          classes: [],
-          error: "Not a .jar file."
-        });
+        results.push(emptyResult(file.name, "skipped", "Not a .jar file."));
         renderReport(results, files.length);
         continue;
       }
 
       if (isAlreadyPatched(file)) {
-        results.push({
-          file: file.name,
-          status: "skipped",
-          patched: 0,
-          skipped: 0,
-          classes: [],
-          error: "Already patched."
-        });
+        results.push(emptyResult(file.name, "skipped", "Already patched."));
         renderReport(results, files.length);
         continue;
       }
@@ -93,11 +79,15 @@ patchButton.addEventListener("click", async () => {
 
         results.push({
           file: file.name,
-          status: "success",
+          status: parsed.failed > 0 ? "partial" : "success",
           patched: parsed.patched,
           skipped: parsed.skipped,
+          failed: parsed.failed,
           classes: parsed.classes,
-          error: "",
+          failures: parsed.failures,
+          error: parsed.failed > 0
+            ? `${parsed.failed} class${parsed.failed === 1 ? " was" : "es were"} left unchanged after a transform error.`
+            : "",
           downloadUrl,
           downloadName: `patched-${file.name}`
         });
@@ -109,14 +99,7 @@ patchButton.addEventListener("click", async () => {
         }
       } catch (error) {
         console.error(error);
-        results.push({
-          file: file.name,
-          status: "failed",
-          patched: 0,
-          skipped: 0,
-          classes: [],
-          error: await errorMessage(error)
-        });
+        results.push(emptyResult(file.name, "failed", await errorMessage(error)));
       } finally {
         cheerpOSRemoveStringFile(inputPath);
       }
@@ -125,14 +108,16 @@ patchButton.addEventListener("click", async () => {
     }
 
     const succeeded = results.filter(result => result.status === "success").length;
+    const partial = results.filter(result => result.status === "partial").length;
     const failed = results.filter(result => result.status === "failed").length;
     const skipped = results.filter(result => result.status === "skipped").length;
-    status.textContent = `Done. ${succeeded} succeeded, ${failed} failed, ${skipped} skipped.`;
+    status.textContent = `Done. ${succeeded} succeeded, ${partial} partial, ${failed} failed, ${skipped} skipped.`;
     updateReportDownload(results);
 
-    if (succeeded === 1 && patchableCount === 1) {
-      const result = results.find(item => item.status === "success");
-      if (result) downloadUrl(result.downloadUrl, result.downloadName);
+    const downloadable = results.filter(hasOutput);
+    if (downloadable.length === 1 && patchableCount === 1) {
+      const result = downloadable[0];
+      downloadUrl(result.downloadUrl, result.downloadName);
     }
   } catch (error) {
     console.error(error);
@@ -177,6 +162,23 @@ function isPatchableJar(file) {
   return isJar(file) && !isAlreadyPatched(file);
 }
 
+function hasOutput(result) {
+  return result.status === "success" || result.status === "partial";
+}
+
+function emptyResult(file, resultStatus, error) {
+  return {
+    file,
+    status: resultStatus,
+    patched: 0,
+    skipped: 0,
+    failed: 0,
+    classes: [],
+    failures: [],
+    error
+  };
+}
+
 function sanitizeFileName(name) {
   const sanitized = name.replace(/[^a-zA-Z0-9._-]/g, "_");
   return sanitized || "plugin.jar";
@@ -184,11 +186,33 @@ function sanitizeFileName(name) {
 
 function parsePatchReport(text) {
   const lines = text.split("\n");
-  const [patchedText = "0", skippedText = "0"] = (lines.shift() ?? "").split("\t");
+  const [patchedText = "0", skippedText = "0", failedText = "0"] =
+    (lines.shift() ?? "").split("\t");
+  const classes = [];
+  const failures = [];
+
+  for (const line of lines) {
+    if (!line) continue;
+    const fields = line.split("\t");
+    const kind = fields.shift();
+
+    if (kind === "P" && fields[0]) {
+      classes.push(fields[0]);
+    } else if (kind === "F") {
+      failures.push({
+        className: fields[0] || "unknown class",
+        type: fields[1] || "java.lang.RuntimeException",
+        message: fields.slice(2).join("\t")
+      });
+    }
+  }
+
   return {
     patched: Number.parseInt(patchedText, 10) || 0,
     skipped: Number.parseInt(skippedText, 10) || 0,
-    classes: lines.filter(Boolean)
+    failed: Number.parseInt(failedText, 10) || failures.length,
+    classes,
+    failures
   };
 }
 
@@ -197,9 +221,10 @@ function renderReport(results, total) {
   resultsContainer.replaceChildren(...results.map(createResultElement));
 
   const succeeded = results.filter(result => result.status === "success").length;
+  const partial = results.filter(result => result.status === "partial").length;
   const failed = results.filter(result => result.status === "failed").length;
   const skipped = results.filter(result => result.status === "skipped").length;
-  reportSummary.textContent = `${results.length}/${total} processed · ${succeeded} success · ${failed} failed · ${skipped} skipped`;
+  reportSummary.textContent = `${results.length}/${total} processed · ${succeeded} success · ${partial} partial · ${failed} failed · ${skipped} skipped`;
 }
 
 function createResultElement(result) {
@@ -215,8 +240,8 @@ function createResultElement(result) {
 
   const meta = document.createElement("span");
   meta.className = "result-meta";
-  meta.textContent = result.status === "success"
-    ? `${result.patched} patched / ${result.skipped} skipped`
+  meta.textContent = hasOutput(result)
+    ? `${result.patched} patched / ${result.skipped} skipped / ${result.failed} unchanged`
     : result.status;
 
   head.append(name, meta);
@@ -229,7 +254,7 @@ function createResultElement(result) {
     article.append(error);
   }
 
-  if (result.status === "success") {
+  if (hasOutput(result)) {
     const links = document.createElement("div");
     links.className = "links";
 
@@ -249,20 +274,46 @@ function createResultElement(result) {
       details.append(summary, pre);
       article.append(details);
     }
+
+    if (result.failures.length > 0) {
+      const details = document.createElement("details");
+      const summary = document.createElement("summary");
+      summary.textContent = `${result.failures.length} unchanged classes`;
+      const pre = document.createElement("pre");
+      pre.textContent = result.failures.map(formatFailure).join("\n");
+      details.append(summary, pre);
+      article.append(details);
+    }
   }
 
   return article;
 }
 
+function formatFailure(failure) {
+  const detail = failure.message ? `: ${failure.message}` : "";
+  return `${failure.className} — ${failure.type}${detail}`;
+}
+
 function updateReportDownload(results) {
   const rows = [
-    ["file", "status", "patched_classes", "skipped_classes", "patched_class_names", "error"],
+    [
+      "file",
+      "status",
+      "patched_classes",
+      "skipped_classes",
+      "unchanged_classes",
+      "patched_class_names",
+      "unchanged_class_details",
+      "error"
+    ],
     ...results.map(result => [
       result.file,
       result.status,
       result.patched,
       result.skipped,
+      result.failed,
       result.classes.join(";"),
+      result.failures.map(formatFailure).join(";"),
       result.error
     ])
   ];


### PR DESCRIPTION
## Summary
- run web-side ASM transforms sequentially instead of through ForkJoinPool
- isolate runtime/ASM failures to the individual class instead of failing the entire JAR
- preserve the original bytecode for classes that cannot be transformed
- report unchanged classes, exception types, and messages in the web UI and CSV report
- keep successful/partial output JARs downloadable

## Why
The browser progressed past the previous `TypeNotPresentException` fix but then surfaced `java.lang.ArrayIndexOutOfBoundsException` while patching. The exception originates inside the Java transform path (`app.js` only receives it at the await site). CheerpJ does not need desktop-style parallel ASM processing, and one problematic class should not invalidate the entire plugin conversion.

The `contentscript.js` MaxListeners/ObjectMultiplex warnings are injected browser-extension content-script messages and are independent of pasta.

## Behavior
If a class transform throws a `RuntimeException` or `LinkageError`, pasta now copies that class unchanged, continues the rest of the JAR, and marks the result `partial` with the exact class and error in the report.