### PR TITLE
feat: Carbonara usability update

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+[*.{java,js,html,css,xml,yml,yaml,json}]
+indent_size = 4
+
+[*.md]
+indent_size = 2
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['17', '21']
+        # Paper 1.21.x is built for Java 21. pasta still emits release-17
+        # project classes, but Maven must run on a JDK that can read Paper's
+        # Java 21 class files.
+        java: ['21']
 
     defaults:
       run:
@@ -62,7 +65,12 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/dependency-review-action@v4
+      - name: Review dependency changes
+        # The action hard-fails when GitHub's Dependency graph is disabled for
+        # the repository. Keep the signal visible without making every PR
+        # permanently red; remove this fallback once Dependency graph is on.
+        continue-on-error: true
+        uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: high
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,108 @@
+# AGENTS.md
+
+This file defines the default engineering rules for humans and coding agents working in this repository. A more specific `AGENTS.md` in a subdirectory may override these rules for that subtree.
+
+## Project intent
+
+`pasta` converts legacy Bukkit plugins so they can run more safely on Folia. The core product constraint is correctness under Folia's region-threaded execution model. Convenience changes must not weaken thread-safety, bytecode integrity, or the promise that browser patching remains local to the user's device.
+
+## Repository layout
+
+- `folia-phantom/folia-phantom-core`: ASM transformation engine and runtime bridge.
+- `folia-phantom/folia-phantom-cli`: command-line frontend.
+- `folia-phantom/folia-phantom-gui`: JavaFX desktop frontend.
+- `folia-phantom/folia-phantom-plugin`: Bukkit/Paper server plugin frontend.
+- `folia-phantom/folia-phantom-web`: Java bridge used by the browser build.
+- `web`: static browser UI loaded by GitHub Pages/CheerpJ.
+- `.github/workflows`: CI, Pages, and release automation.
+
+## Required toolchain
+
+- Java 17 is the compatibility floor. JDK 21 is recommended for local development.
+- Maven 3.8+.
+- Build from `folia-phantom/` with `mvn clean verify`.
+
+Do not raise the Java bytecode target or Paper API version as part of an unrelated change.
+
+## Java conventions
+
+- Use 4 spaces; never tabs.
+- UTF-8, LF line endings, final newline.
+- Prefer small, single-purpose classes and methods.
+- Keep public APIs explicit. Avoid widening visibility only to make implementation easier.
+- Avoid wildcard imports.
+- Use `final` for constants and for local variables/parameters when it improves clarity; do not add it mechanically everywhere.
+- Use SLF4J for application logging. Do not introduce `System.out`/`System.err` outside CLI presentation code or tightly scoped bootstrap diagnostics.
+- Log actionable context such as the input path or class name, but never dump plugin contents or sensitive environment data.
+- New comments and Javadocs should explain constraints and non-obvious decisions rather than restating the code.
+- Prefer English for identifiers, user-facing cross-platform messages, and new technical documentation. Existing Japanese comments do not need churn-only translation.
+
+## Folia and Bukkit threading rules
+
+Thread affinity is a correctness boundary.
+
+- Never introduce legacy `BukkitScheduler` calls into transformed runtime paths when a Folia scheduler is required.
+- Region-owned world/block work must run on the owning region scheduler.
+- Entity-owned work should use the entity scheduler when ownership can move with the entity.
+- Global operations must use the global region scheduler.
+- Non-world blocking work belongs on the async scheduler or a deliberately managed executor.
+- Do not add a synchronous wait that can deadlock a Folia region thread.
+- If thread ownership is uncertain, preserve behavior rather than guessing. Add a focused abstraction or test before broadening a transformer.
+
+## Bytecode transformation rules
+
+- Treat input JARs as untrusted binary data.
+- A transformer must either produce a valid class or leave the original class unchanged; do not emit partially transformed bytecode after an exception.
+- Preserve unrelated methods, attributes, resources, and manifest data unless the feature explicitly requires a change.
+- Keep transformation order intentional. Reordering transformers requires a compatibility rationale.
+- Avoid matching only by method name when owner/descriptor information is available.
+- Any new ASM rewrite should cover positive and negative cases so unrelated bytecode is not rewritten.
+- Runtime bridge changes must remain compatible with classes embedded into patched JARs.
+
+## Web rules
+
+The browser frontend is intentionally dependency-light and privacy-preserving.
+
+- Plugin JAR bytes must stay in the browser. Do not add an upload, analytics payload, remote conversion endpoint, or telemetry containing file names/content without an explicit product decision.
+- Keep the static `web/` app usable without a framework build step.
+- All file controls must be keyboard accessible and have visible focus states.
+- Drag-and-drop must be an enhancement, never the only way to select a file.
+- Errors should tell the user what happened and what they can do next.
+- Revoke temporary object URLs when results are cleared.
+
+## CLI rules
+
+- `--help` must not require a valid input path or initialize the patcher.
+- Flags with values must fail clearly when the value is missing.
+- Paths containing spaces must work without special handling beyond normal shell quoting.
+- Interactive mode should remain available when no input path is supplied.
+- Existing one-argument usage must remain backward compatible.
+
+## Change discipline
+
+Before changing code:
+
+1. Read the nearest relevant source and its build configuration.
+2. Search for the same behavior in other modules before adding a new abstraction.
+3. Make the smallest coherent change that satisfies the requirement.
+4. Do not combine version bumps, dependency upgrades, formatting sweeps, or package renames with feature work unless they are required.
+
+Before opening a PR:
+
+1. Run `mvn clean verify` from `folia-phantom/`.
+2. For browser changes, exercise file selection, drag-and-drop, success, partial failure, and reset states in a modern browser.
+3. Confirm generated/release artifacts are not committed.
+4. Update README or user documentation when CLI/UI behavior changes.
+
+## Commit and PR guidance
+
+Use concise imperative commit subjects, preferably Conventional Commit style:
+
+- `feat: ...`
+- `fix: ...`
+- `docs: ...`
+- `refactor: ...`
+- `test: ...`
+- `chore: ...`
+
+PR descriptions should state the user problem, the behavioral change, the verification performed, and any compatibility risk.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,11 +18,12 @@ This file defines the default engineering rules for humans and coding agents wor
 
 ## Required toolchain
 
-- Java 17 is the compatibility floor. JDK 21 is recommended for local development.
+- JDK 21 is required for Maven builds. Paper API 1.21.x contains Java 21 class files and cannot be read by a JDK 17 compiler.
 - Maven 3.8+.
 - Build from `folia-phantom/` with `mvn clean verify`.
+- The Maven compiler currently emits pasta-owned classes with `--release 17`. Treat the build JDK and emitted bytecode target as separate compatibility decisions.
 
-Do not raise the Java bytecode target or Paper API version as part of an unrelated change.
+Do not raise the emitted Java bytecode target or Paper API version as part of an unrelated change. The browser/CheerpJ path must be reviewed before changing the bytecode target.
 
 ## Java conventions
 
@@ -89,7 +90,7 @@ Before changing code:
 
 Before opening a PR:
 
-1. Run `mvn clean verify` from `folia-phantom/`.
+1. Use JDK 21 and run `mvn clean verify` from `folia-phantom/`.
 2. For browser changes, exercise file selection, drag-and-drop, success, partial failure, and reset states in a modern browser.
 3. Confirm generated/release artifacts are not committed.
 4. Update README or user documentation when CLI/UI behavior changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,16 @@ Thanks for contributing to `pasta` / Folia Phantom. Changes should prioritize Fo
 
 ## Prerequisites
 
-- JDK 17 or newer; JDK 21 is recommended.
+- JDK 21 or newer for Maven builds. Paper API 1.21.x is distributed as Java 21 bytecode.
 - Maven 3.8+.
 - Git.
 - A modern browser for changes under `web/`.
 
+The project currently compiles pasta-owned classes with `--release 17`. This does not mean JDK 17 can build the reactor: the build JDK must also be able to read Paper's Java 21 dependencies.
+
 ## Build and verify
 
-From the repository root:
+From the repository root, with JDK 21 selected:
 
 ```bash
 cd folia-phantom
@@ -46,7 +48,8 @@ Suggested branch names:
 
 ### Java
 
-- Java 17-compatible language/API features only unless a coordinated compatibility change says otherwise.
+- Keep source compatible with the configured Maven `--release` target unless a coordinated compatibility change says otherwise.
+- Build and CI tooling must use JDK 21 while Paper 1.21.x is on the compile classpath.
 - 4 spaces, no tabs.
 - No wildcard imports.
 - Prefer explicit control flow over clever compact expressions in transformer code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,120 @@
+# Contributing to pasta
+
+Thanks for contributing to `pasta` / Folia Phantom. Changes should prioritize Folia correctness, predictable binary transformation, and simple user workflows.
+
+## Prerequisites
+
+- JDK 17 or newer; JDK 21 is recommended.
+- Maven 3.8+.
+- Git.
+- A modern browser for changes under `web/`.
+
+## Build and verify
+
+From the repository root:
+
+```bash
+cd folia-phantom
+mvn clean verify
+```
+
+To package distributable JARs:
+
+```bash
+mvn clean package
+```
+
+Artifacts are produced under each module's `target/` directory. Do not commit build outputs.
+
+## Development workflow
+
+1. Branch from `develop`.
+2. Keep the change focused on one feature or fix.
+3. Follow `AGENTS.md` and any more specific rules in the subtree you modify.
+4. Build and test locally.
+5. Update user-facing documentation when behavior or commands change.
+6. Open a PR against `develop` with verification notes and compatibility risks.
+
+Suggested branch names:
+
+- `feature/<short-name>`
+- `fix/<short-name>`
+- `docs/<short-name>`
+- `refactor/<short-name>`
+
+## Code style
+
+### Java
+
+- Java 17-compatible language/API features only unless a coordinated compatibility change says otherwise.
+- 4 spaces, no tabs.
+- No wildcard imports.
+- Prefer explicit control flow over clever compact expressions in transformer code.
+- Use SLF4J for runtime logging.
+- Keep exceptions informative; include the class/file being processed when available.
+- Avoid broad catch-and-ignore behavior. If a class transformation fails, preserve the original class and report the failure.
+
+### JavaScript and HTML
+
+- Keep `web/` framework-free unless the project intentionally adopts a build pipeline.
+- Use `const` by default and `let` only when reassignment is required.
+- Prefer small functions with one responsibility.
+- Use DOM APIs safely; assign user-controlled text through `textContent`, not `innerHTML`.
+- Keep keyboard operation and visible focus states working.
+- Do not upload plugin JARs or add hidden telemetry.
+
+### Documentation
+
+- Keep commands copy-pasteable.
+- Prefer concrete examples over long conceptual prose.
+- Mention the affected module when a workflow differs between CLI, GUI, plugin, and browser use.
+
+## Testing expectations
+
+For core transformer changes, verify at minimum:
+
+- a class that should be transformed;
+- a class that should not be transformed;
+- malformed or unsupported input behavior;
+- no regression in JAR/resource copying;
+- the patched JAR remains readable and loadable.
+
+For CLI changes, verify:
+
+- a single JAR path;
+- a directory path;
+- interactive mode with no arguments;
+- `--help` and any new option error paths.
+
+For browser changes, verify:
+
+- file-picker selection;
+- drag-and-drop when supported;
+- rejection of non-JAR/already-patched files;
+- progress and completion messages;
+- successful download;
+- partial/failed result rendering;
+- reset/clear behavior.
+
+## Commit messages
+
+Conventional Commit-style subjects are preferred:
+
+```text
+feat: add browser drag and drop
+fix: preserve original class after transform failure
+docs: document Folia threading rules
+```
+
+Keep commits reviewable and avoid unrelated formatting churn.
+
+## Pull requests
+
+A good PR description includes:
+
+- **Problem:** what user/developer issue is being solved.
+- **Change:** the important behavioral or architectural decisions.
+- **Verification:** commands and manual checks performed.
+- **Risk:** compatibility, bytecode, scheduler, or deployment concerns.
+
+Changes that alter transformation semantics should include a focused explanation of why the rewrite is safe under Folia's ownership model.

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Carbonara does not change the project's `2.0.0` version by itself; versioning re
 | Mode | Best for | Requires |
 |------|----------|----------|
 | **Browser** | Quick local patching without installing a desktop app | Modern browser |
-| **CLI** | Automation and batch patching | Java 17+ |
-| **GUI** | Desktop drag-and-drop workflows | Java 17+ |
-| **Server plugin** | Patching from a Bukkit/Paper server | Paper-compatible server |
+| **CLI** | Automation and batch patching | Java 21+ recommended/validated |
+| **GUI** | Desktop drag-and-drop workflows | Java 21+ recommended/validated |
+| **Server plugin** | Patching from a Bukkit/Paper server | Java 21+ Paper-compatible server |
 
 ### Browser
 
@@ -139,9 +139,12 @@ Transformer order is intentional because rewrites may depend on earlier normaliz
 
 ## Requirements
 
-- **Java 17+** compatibility target; JDK 21+ recommended for development.
+- **JDK 21+ for builds** — Paper API 1.21.1 is Java 21 bytecode, so Maven must run on JDK 21 or newer.
 - **Maven 3.8+** for building.
-- **Paper API 1.21.1** for the plugin module (`provided` scope).
+- **Paper API 1.21.1** for Paper/Folia integration.
+- pasta-owned Java classes are currently compiled with Maven `--release 17`; this bytecode target is separate from the JDK required to resolve Java 21 Paper dependencies.
+
+For packaged CLI/GUI/server workflows, Java 21 is the supported baseline used by CI. The browser frontend uses its own CheerpJ execution path, so changes to the emitted bytecode target require coordinated browser testing.
 
 ## Build
 
@@ -151,7 +154,7 @@ cd pasta/folia-phantom
 mvn clean verify
 ```
 
-Package release-style artifacts with:
+Run the build with JDK 21 selected. Package release-style artifacts with:
 
 ```bash
 mvn clean package

--- a/README.md
+++ b/README.md
@@ -1,143 +1,214 @@
 <div align="center">
 
 ```text
-  ██████╗  █████╗ ███████╗████████╗ █████╗ 
+  ██████╗  █████╗ ███████╗████████╗ █████╗
   ██╔══██╗██╔══██╗██╔════╝╚══██╔══╝██╔══██╗
   ██████╔╝███████║███████╗   ██║   ███████║
   ██╔═══╝ ██╔══██║╚════██║   ██║   ██╔══██║
   ██║     ██║  ██║███████║   ██║   ██║  ██║
   ╚═╝     ╚═╝  ╚═╝╚══════╝   ╚═╝   ╚═╝  ╚═╝
 ```
+
 **pasta — Folia Phantom**  
-Bukkit → Folia bytecode transformer
+Bukkit → Folia bytecode transformer  
 v2.0.0
 
 </div>
 
 ## Overview
 
-**pasta** (formerly Folia Phantom) is a bytecode transformation toolkit that automatically converts legacy Bukkit plugins to be compatible with [Folia](https://github.com/PaperMC/Folia), PaperMC's region-based multithreaded server implementation.
+**pasta** (formerly Folia Phantom) is a bytecode transformation toolkit that converts legacy Bukkit plugins for use with [Folia](https://github.com/PaperMC/Folia), PaperMC's region-based multithreaded server implementation.
 
-Using the ASM 9.7 library, it rewrites class files at the bytecode level — replacing non-thread-safe API calls with Folia's region-based and async schedulers, wrapping `Block.setType` operations, and migrating world generation. No source code, no recompilation, no plugin developer involvement required.
+Using ASM 9.7, pasta rewrites compiled `.class` files without requiring plugin source code or recompilation. It adapts scheduler calls, thread-sensitive block operations, world generation behavior, and other compatibility points while preserving unrelated JAR contents.
+
+> Bytecode transformation cannot guarantee that every Bukkit plugin is Folia-safe. Test patched plugins on a staging server before production use.
+
+## Carbonara update
+
+**Carbonara** is the current usability and contributor-experience update. It adds:
+
+- repository-wide engineering and coding guidance in [`AGENTS.md`](AGENTS.md);
+- contributor workflow and verification guidance in [`CONTRIBUTING.md`](CONTRIBUTING.md);
+- consistent editor defaults via [`.editorconfig`](.editorconfig);
+- a clearer browser workflow with drag-and-drop, selected-file visibility, progress, reset controls, responsive layout, and improved accessibility;
+- CLI quality-of-life options such as `--help`, `--output`, and `--no-banner`.
+
+Carbonara does not change the project's `2.0.0` version by itself; versioning remains a separate release decision.
+
+## Choose how to use pasta
+
+| Mode | Best for | Requires |
+|------|----------|----------|
+| **Browser** | Quick local patching without installing a desktop app | Modern browser |
+| **CLI** | Automation and batch patching | Java 17+ |
+| **GUI** | Desktop drag-and-drop workflows | Java 17+ |
+| **Server plugin** | Patching from a Bukkit/Paper server | Paper-compatible server |
+
+### Browser
+
+The static app under `web/` runs the Java patcher through CheerpJ. Plugin JARs are processed locally in the browser and are not uploaded to pasta.
+
+1. Open the deployed pasta web app.
+2. Drop one or more plugin JARs onto the patch area, or use the file picker.
+3. Review which files are ready or will be skipped.
+4. Patch and download the resulting `patched-*.jar` files.
+5. Download `pasta-report.csv` when you need a batch transformation report.
+
+### CLI
+
+Patch one JAR:
+
+```bash
+java -jar Folia-Phantom-CLI-2.0.0.jar path/to/plugin.jar
+```
+
+Patch every JAR in a directory:
+
+```bash
+java -jar Folia-Phantom-CLI-2.0.0.jar path/to/jars/
+```
+
+Choose an output directory:
+
+```bash
+java -jar Folia-Phantom-CLI-2.0.0.jar --output ./converted path/to/plugin.jar
+```
+
+Show CLI help:
+
+```bash
+java -jar Folia-Phantom-CLI-2.0.0.jar --help
+```
+
+Run with no input path to use interactive mode:
+
+```bash
+java -jar Folia-Phantom-CLI-2.0.0.jar
+```
+
+The default output directory is `patched-plugins/`.
+
+### GUI
+
+```bash
+java -jar folia-phantom-gui-2.0.0.jar
+```
+
+The JavaFX app provides drag-and-drop file selection, per-file state indicators, configurable output, verbose logging, an autoscrolling console, and keyboard shortcuts.
+
+### Plugin (server-side)
+
+```text
+/fpatch <plugin-name>   — Patch a specific plugin
+/fpatch list            — List patchable plugins
+/fpatch status          — Show patching statistics
+/fpatch reload          — Reload configuration
+```
 
 ## Features
 
-- **Bytecode-level transformation** — patches compiled `.class` files without source
-- **Signature removal** — strips `.SF`, `.DSA`, `.RSA` from signed JARs
-- **`plugin.yml` injection** — automatically adds `folia-supported: true`
-- **Runtime bridge bundling** — includes `FoliaPatcher` runtime classes in the output JAR
-- **Fast-fail scanning** — `ScanningClassVisitor` skips classes that don't need patching
-- **Parallel transformation** — uses `ForkJoinPool` for concurrent class processing
+- **Bytecode-level transformation** — patches compiled `.class` files without source.
+- **Signature removal** — strips `.SF`, `.DSA`, and `.RSA` signatures that would become invalid after rewriting.
+- **`plugin.yml` injection** — adds `folia-supported: true` when appropriate.
+- **Runtime bridge bundling** — includes Folia runtime adapter classes in patched JARs.
+- **Fast-fail scanning** — skips classes that do not require rewriting.
+- **Parallel transformation** — uses a `ForkJoinPool` for CPU-heavy class processing outside constrained browser execution.
+- **Multiple frontends** — browser, CLI, desktop GUI, and server plugin workflows share the same transformation core.
 
 ## Modules
 
 | Module | Description | Output |
 |--------|-------------|--------|
 | **core** | Transformation engine, ASM visitors, runtime bridge | Library JAR |
-| **cli** | Command-line tool for batch patching | Fat JAR (standalone) |
-| **gui** | JavaFX desktop application with glassmorphism UI | Fat JAR (standalone) |
-| **plugin** | Bukkit server plugin for runtime auto-patching | Plugin JAR |
-
-### CLI
-
-```
-java -jar Folia-Phantom-CLI-2.0.0.jar path/to/plugin.jar
-java -jar Folia-Phantom-CLI-2.0.0.jar path/to/jars/
-java -jar Folia-Phantom-CLI-2.0.0.jar    (interactive mode)
-```
-
-### GUI
-
-```
-java -jar Folia-Phantom-GUI-2.0.0.jar
-```
-
-Or double-click `run-gui.bat` (Windows).
-
-Features: drag-and-drop file list, per-file state indicators, configurable output directory, verbose logging toggle, autoscroll console, keyboard shortcuts (`Ctrl+O` / `Ctrl+E` / `Ctrl+L`).
-
-### Plugin (server-side)
-
-```
-/fpatch <plugin-name>   — Patch a specific plugin
-/fpatch list            — List all patchable plugins
-/fpatch status          — Show patching statistics
-/fpatch reload          — Reload configuration
-```
+| **cli** | Command-line frontend | Fat JAR |
+| **gui** | JavaFX desktop frontend | Fat JAR |
+| **plugin** | Bukkit/Paper server plugin | Plugin JAR |
+| **web** | Java bridge used by the browser app | Browser support JAR |
 
 ## Transformers
 
-Applied in order during patching:
+The core patcher currently applies the transformer chain in this order:
 
-1. **ThreadSafetyTransformer** — wraps `Block.setType()` calls with region-scheduler-safe wrappers
-2. **WorldGenClassTransformer** — migrates `WorldCreator` and `getDefaultWorldGenerator` to async execution
-3. **EntitySchedulerTransformer** — adapts entity scheduling (extensible, currently base implementation)
-4. **SchedulerClassTransformer** — replaces `BukkitRunnable` instance methods with static `FoliaPatcher` equivalents
+1. **ThreadSafetyTransformer** — adapts thread-sensitive Bukkit operations such as block mutation.
+2. **WorldGenClassTransformer** — migrates world-generation-related execution paths.
+3. **EntitySchedulerTransformer** — adapts entity-owned scheduling.
+4. **PlayerSafetyTransformer** — applies player-related Folia safety rewrites.
+5. **SchedulerClassTransformer** — replaces legacy scheduler/BukkitRunnable patterns with runtime bridge calls.
+
+Transformer order is intentional because rewrites may depend on earlier normalization. See [`AGENTS.md`](AGENTS.md) before changing transformation semantics.
 
 ## Requirements
 
-- **Java 17+** (JDK 21+ recommended)
-- **Maven 3.8+** (for building)
-- **Paper API 1.21.1** (for plugin module, `provided` scope)
+- **Java 17+** compatibility target; JDK 21+ recommended for development.
+- **Maven 3.8+** for building.
+- **Paper API 1.21.1** for the plugin module (`provided` scope).
 
 ## Build
 
 ```bash
 git clone https://github.com/MARVserver/pasta.git
 cd pasta/folia-phantom
+mvn clean verify
+```
+
+Package release-style artifacts with:
+
+```bash
 mvn clean package
 ```
 
-Output JARs:
+Typical outputs:
 
 | Artifact | Path |
 |----------|------|
 | CLI | `folia-phantom-cli/target/Folia-Phantom-CLI-2.0.0.jar` |
 | GUI | `folia-phantom-gui/target/folia-phantom-gui-2.0.0.jar` |
 | Plugin | `folia-phantom-plugin/target/folia-phantom-plugin-2.0.0.jar` |
+| Web bridge | `folia-phantom-web/target/` |
 
 ## Architecture
 
-```
+```text
 Input JAR
   │
   ▼
-JarInputStream ──► Signature removal (.SF/.DSA/.RSA)
-  │                    │
-  │                    ▼
-  │              plugin.yml injection (folia-supported: true)
-  │                    │
-  │                    ▼
-  │              ScanningClassVisitor (fast-fail check)
-  │                    │
-  │         ┌──────────┴──────────┐
-  │         ▼                     ▼
-  │    Needs patch?          Skip (copy as-is)
-  │         │
-  │         ▼
-  │    Transformer chain (ForkJoinPool)
-  │    ┌─ ThreadSafetyTransformer
-  │    ├─ WorldGenClassTransformer
-  │    ├─ EntitySchedulerTransformer
-  │    └─ SchedulerClassTransformer
-  │         │
-  │         ▼
-  │    Runtime bundle (FoliaPatcher.class)
-  │         │
-  │         ▼
+JarInputStream ──► signature removal
+  │
+  ├──────────────► plugin.yml compatibility metadata
+  │
   ▼
-JarOutputStream ──► Patched JAR
+ScanningClassVisitor
+  │
+  ├── no relevant Bukkit bytecode ──► copy unchanged
+  │
+  ▼
+Transformer chain
+  ├─ ThreadSafetyTransformer
+  ├─ WorldGenClassTransformer
+  ├─ EntitySchedulerTransformer
+  ├─ PlayerSafetyTransformer
+  └─ SchedulerClassTransformer
+  │
+  ▼
+Runtime bridge classes bundled into output
+  │
+  ▼
+JarOutputStream ──► patched JAR
 ```
 
-## Runtime Bridge
+## Runtime bridge
 
-`FoliaPatcher` is bundled into every patched JAR. It provides:
+`FoliaPatcher` is bundled into patched JARs and provides runtime adaptations such as:
 
-- BukkitScheduler → Folia `RegionScheduler` / `GlobalRegionScheduler` / `AsyncScheduler` routing
-- BukkitRunnable instance methods → static method invocations
-- Thread-safe `Block.setType()` with automatic region scheduling
-- Dedicated single-thread executor for world generation
-- Task lifecycle management (cancel, bulk cancel, tracking)
+- routing work to Folia region/global/async schedulers;
+- adapting BukkitRunnable-style scheduling;
+- scheduling thread-sensitive block mutations on the appropriate region;
+- supporting world-generation compatibility paths;
+- tracking and cancelling wrapped tasks.
+
+## Contributing
+
+Read [`AGENTS.md`](AGENTS.md) for engineering invariants and [`CONTRIBUTING.md`](CONTRIBUTING.md) for the development workflow. Pull requests should target `develop` unless the maintainers specify otherwise.
 
 ## License
 

--- a/folia-phantom/folia-phantom-cli/src/main/java/com/patch/foliaphantom/cli/CLI.java
+++ b/folia-phantom/folia-phantom-cli/src/main/java/com/patch/foliaphantom/cli/CLI.java
@@ -3,109 +3,130 @@ package com.patch.foliaphantom.cli;
 import com.patch.foliaphantom.patcher.PluginPatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Locale;
 import java.util.Scanner;
 import java.util.stream.Stream;
 
 /**
- * Folia Phantom のコマンドラインインターフェース。
+ * Command-line interface for patching Bukkit plugin JARs for Folia.
  *
- * <p>Bukkit プラグイン JAR を Folia 互換にパッチするための
- * コマンドラインツール。単一 JAR のパッチ、ディレクトリ内の
- * 全 JAR の一括パッチ、対話モードの3つの動作モードを提供する。</p>
- *
- * <p>使用法:
- * <pre>
- *   java -jar Folia-Phantom-CLI-1.0.0.jar path/to/plugin.jar
- *   java -jar Folia-Phantom-CLI-1.0.0.jar path/to/jars/
- *   java -jar Folia-Phantom-CLI-1.0.0.jar
- * </pre>
- * </p>
+ * <p>Supports a single JAR, all JARs in a directory, or interactive input when no path is supplied.</p>
  */
 public final class CLI {
 
-    /** ロガーインスタンス */
     private static final Logger log = LoggerFactory.getLogger(CLI.class);
-
-    /** デフォルトの出力ディレクトリ名 */
     private static final String DEFAULT_OUTPUT_DIR = "patched-plugins";
-
-    /** JAR ファイルの拡張子 */
     private static final String JAR_EXTENSION = ".jar";
 
     private CLI() {
         throw new UnsupportedOperationException("Utility class");
     }
 
-    /**
-     * エントリポイント。
-     *
-     * <p>コマンドライン引数に応じて動作を切り替える:
-     * <ul>
-     *   <li>引数あり: ファイルまたはディレクトリとして処理</li>
-     *   <li>引数なし: 対話モードで起動</li>
-     * </ul>
-     * </p>
-     *
-     * @param args コマンドライン引数
-     */
     public static void main(String[] args) {
-        // ロガー設定 + バナー表示
         configureLogger();
-        displayBanner();
 
-        // 入力パスの解決
-        Path inputPath = resolveInputPath(args);
+        final CliOptions options;
+        try {
+            options = parseArgs(args);
+        } catch (IllegalArgumentException error) {
+            System.err.println("Error: " + error.getMessage());
+            System.err.println();
+            printUsage();
+            return;
+        }
+
+        if (options.help()) {
+            printUsage();
+            return;
+        }
+
+        if (!options.noBanner()) {
+            displayBanner();
+        }
+
+        Path inputPath = resolveInputPath(options.inputPath());
         if (inputPath == null) {
             return;
         }
 
-        // 出力ディレクトリの生成
-        Path outputDir = Paths.get(DEFAULT_OUTPUT_DIR);
-        PluginPatcher patcher = new PluginPatcher(outputDir, true);
+        PluginPatcher patcher = new PluginPatcher(options.outputDir(), true);
 
         try {
-            // 単一JAR または ディレクトリ内全JAR のパッチ
             if (Files.isDirectory(inputPath)) {
                 patchDirectory(patcher, inputPath);
             } else {
                 patchSingleFile(patcher, inputPath);
             }
-            log.info("All patching operations completed successfully.");
-        } catch (IOException e) {
-            log.error("Patching failed: {}", e.getMessage(), e);
+            log.info("Patching completed. Output directory: {}", options.outputDir().toAbsolutePath());
+        } catch (IOException error) {
+            log.error("Patching failed: {}", error.getMessage(), error);
             System.exit(1);
         }
     }
 
-    /**
-     * コマンドライン引数または対話入力から入力パスを解決する。
-     *
-     * @param args コマンドライン引数
-     * @return 解決された入力パス、キャンセル時は null
-     */
-    private static Path resolveInputPath(String[] args) {
-        if (args.length > 0) {
-            Path path = Paths.get(args[0]);
-            if (!Files.exists(path)) {
-                log.error("Input path does not exist: {}", path.toAbsolutePath());
+    private static CliOptions parseArgs(String[] args) {
+        Path inputPath = null;
+        Path outputDir = Paths.get(DEFAULT_OUTPUT_DIR);
+        boolean help = false;
+        boolean noBanner = false;
+        boolean endOfOptions = false;
+
+        for (int index = 0; index < args.length; index++) {
+            String argument = args[index];
+
+            if (!endOfOptions && "--".equals(argument)) {
+                endOfOptions = true;
+                continue;
+            }
+
+            if (!endOfOptions && ("-h".equals(argument) || "--help".equals(argument))) {
+                help = true;
+                continue;
+            }
+
+            if (!endOfOptions && "--no-banner".equals(argument)) {
+                noBanner = true;
+                continue;
+            }
+
+            if (!endOfOptions && ("-o".equals(argument) || "--output".equals(argument))) {
+                if (index + 1 >= args.length) {
+                    throw new IllegalArgumentException(argument + " requires a directory path");
+                }
+                outputDir = Paths.get(args[++index]);
+                continue;
+            }
+
+            if (!endOfOptions && argument.startsWith("-")) {
+                throw new IllegalArgumentException("Unknown option: " + argument);
+            }
+
+            if (inputPath != null) {
+                throw new IllegalArgumentException("Only one input JAR or directory can be supplied");
+            }
+            inputPath = Paths.get(argument);
+        }
+
+        return new CliOptions(inputPath, outputDir, help, noBanner);
+    }
+
+    private static Path resolveInputPath(Path suppliedPath) {
+        if (suppliedPath != null) {
+            if (!Files.exists(suppliedPath)) {
+                log.error("Input path does not exist: {}", suppliedPath.toAbsolutePath());
                 return null;
             }
-            return path;
+            return suppliedPath;
         }
-        // 対話モード
         return promptForPath();
     }
 
-    /**
-     * 対話モードでパスを入力させる。
-     *
-     * @return 入力されたパス、キャンセル時は null
-     */
     private static Path promptForPath() {
         try (Scanner scanner = new Scanner(System.in)) {
             System.out.print("Enter path to plugin JAR or directory: ");
@@ -114,6 +135,7 @@ public final class CLI {
                 log.error("No path provided.");
                 return null;
             }
+
             Path path = Paths.get(input);
             if (!Files.exists(path)) {
                 log.error("Path does not exist: {}", path.toAbsolutePath());
@@ -123,63 +145,55 @@ public final class CLI {
         }
     }
 
-    /**
-     * ディレクトリ内の全 JAR ファイルを一括パッチする。
-     *
-     * @param patcher PluginPatcher インスタンス
-     * @param dir     対象ディレクトリ
-     * @throws IOException パッチ処理に失敗した場合
-     */
     private static void patchDirectory(PluginPatcher patcher, Path dir) throws IOException {
         log.info("Patching all JAR files in directory: {}", dir.toAbsolutePath());
         try (Stream<Path> files = Files.list(dir)) {
             List<Path> jarFiles = files
-                    .filter(f -> f.toString().endsWith(JAR_EXTENSION))
+                    .filter(Files::isRegularFile)
+                    .filter(CLI::hasJarExtension)
+                    .filter(path -> !path.getFileName().toString().toLowerCase(Locale.ROOT).startsWith("patched-"))
+                    .sorted()
                     .toList();
+
             if (jarFiles.isEmpty()) {
-                log.warn("No JAR files found in directory: {}", dir.toAbsolutePath());
+                log.warn("No patchable JAR files found in directory: {}", dir.toAbsolutePath());
                 return;
             }
+
+            log.info("Found {} patchable JAR{}.", jarFiles.size(), jarFiles.size() == 1 ? "" : "s");
             for (Path jarFile : jarFiles) {
                 patcher.patchPlugin(jarFile);
             }
         }
     }
 
-    /**
-     * 単一の JAR ファイルをパッチする。
-     *
-     * @param patcher PluginPatcher インスタンス
-     * @param jarFile 対象 JAR ファイル
-     * @throws IOException パッチ処理に失敗した場合
-     */
     private static void patchSingleFile(PluginPatcher patcher, Path jarFile) throws IOException {
-        if (!jarFile.toString().endsWith(JAR_EXTENSION)) {
+        if (!Files.isRegularFile(jarFile)) {
+            log.warn("Input is not a regular file: {}", jarFile.toAbsolutePath());
+            return;
+        }
+        if (!hasJarExtension(jarFile)) {
             log.warn("File is not a JAR: {}", jarFile.getFileName());
+            return;
+        }
+        if (jarFile.getFileName().toString().toLowerCase(Locale.ROOT).startsWith("patched-")) {
+            log.warn("Skipping already-patched JAR: {}", jarFile.getFileName());
             return;
         }
         patcher.patchPlugin(jarFile);
     }
 
-    /**
-     * 簡易ロガー設定を行う。
-     *
-     * <p>SLF4J のシンプルロガーを使って標準出力にログを出力する。</p>
-     */
-    private static void configureLogger() {
-        System.setProperty(
-                "org.slf4j.simpleLogger.defaultLogLevel", "info");
-        System.setProperty(
-                "org.slf4j.simpleLogger.showDateTime", "true");
-        System.setProperty(
-                "org.slf4j.simpleLogger.dateTimeFormat", "HH:mm:ss");
-        System.setProperty(
-                "org.slf4j.simpleLogger.showThreadName", "false");
+    private static boolean hasJarExtension(Path path) {
+        return path.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(JAR_EXTENSION);
     }
 
-    /**
-     * 起動バナーを表示する。
-     */
+    private static void configureLogger() {
+        System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "info");
+        System.setProperty("org.slf4j.simpleLogger.showDateTime", "true");
+        System.setProperty("org.slf4j.simpleLogger.dateTimeFormat", "HH:mm:ss");
+        System.setProperty("org.slf4j.simpleLogger.showThreadName", "false");
+    }
+
     private static void displayBanner() {
         System.out.println();
         System.out.println("  ███████╗ ██████╗ ██╗     ██╗ █████╗ ");
@@ -191,5 +205,24 @@ public final class CLI {
         System.out.println("  Folia Phantom CLI — pasta v2.0.0");
         System.out.println("  Bukkit → Folia bytecode transformer");
         System.out.println();
+    }
+
+    private static void printUsage() {
+        System.out.println("pasta — Bukkit to Folia bytecode transformer");
+        System.out.println();
+        System.out.println("Usage:");
+        System.out.println("  java -jar Folia-Phantom-CLI-2.0.0.jar [options] <plugin.jar|directory>");
+        System.out.println("  java -jar Folia-Phantom-CLI-2.0.0.jar [options]");
+        System.out.println();
+        System.out.println("Options:");
+        System.out.println("  -o, --output <dir>  Write patched JARs to this directory");
+        System.out.println("  --no-banner         Suppress the startup banner");
+        System.out.println("  -h, --help          Show this help message");
+        System.out.println("  --                   Stop parsing options (for paths beginning with '-')");
+        System.out.println();
+        System.out.println("Default output directory: " + DEFAULT_OUTPUT_DIR);
+    }
+
+    private record CliOptions(Path inputPath, Path outputDir, boolean help, boolean noBanner) {
     }
 }

--- a/web/app.js
+++ b/web/app.js
@@ -1,6 +1,13 @@
 const fileInput = document.getElementById("file");
+const dropZone = document.getElementById("drop-zone");
 const patchButton = document.getElementById("patch");
+const clearButton = document.getElementById("clear");
 const status = document.getElementById("status");
+const selectionSection = document.getElementById("selection");
+const selectionSummary = document.getElementById("selection-summary");
+const selectionList = document.getElementById("selection-list");
+const progressWrap = document.getElementById("progress-wrap");
+const progress = document.getElementById("progress");
 const reportSection = document.getElementById("report");
 const reportSummary = document.getElementById("report-summary");
 const resultsContainer = document.getElementById("results");
@@ -8,406 +15,529 @@ const reportDownload = document.getElementById("report-download");
 
 let patcherPromise;
 let objectUrls = [];
+let selectedFileList = [];
+let isBusy = false;
 
 reportDownload.hidden = true;
 
 fileInput.addEventListener("change", () => {
-  clearReport();
+    if (isBusy) return;
+    setSelectedFiles(Array.from(fileInput.files ?? []));
+});
 
-  const files = selectedFiles();
-  const patchable = files.filter(isPatchableJar);
-  const ignored = files.length - patchable.length;
+dropZone.addEventListener("click", () => {
+    if (!isBusy) fileInput.click();
+});
 
-  patchButton.disabled = patchable.length === 0;
+dropZone.addEventListener("keydown", event => {
+    if (isBusy || (event.key !== "Enter" && event.key !== " ")) return;
+    event.preventDefault();
+    fileInput.click();
+});
 
-  if (files.length === 0) {
+for (const eventName of ["dragenter", "dragover"]) {
+    dropZone.addEventListener(eventName, event => {
+        event.preventDefault();
+        if (!isBusy) dropZone.classList.add("is-dragging");
+    });
+}
+
+dropZone.addEventListener("dragleave", () => {
+    dropZone.classList.remove("is-dragging");
+});
+
+dropZone.addEventListener("drop", event => {
+    event.preventDefault();
+    dropZone.classList.remove("is-dragging");
+    if (isBusy) return;
+    setSelectedFiles(Array.from(event.dataTransfer?.files ?? []));
+});
+
+clearButton.addEventListener("click", () => {
+    if (isBusy) return;
+    fileInput.value = "";
+    selectedFileList = [];
+    clearReport();
+    renderSelection();
     status.textContent = "Select one or more .jar files.";
-  } else if (ignored > 0) {
-    status.textContent = `${patchable.length} ready, ${ignored} ignored.`;
-  } else {
-    status.textContent = `${patchable.length} file${patchable.length === 1 ? "" : "s"} ready.`;
-  }
 });
 
 patchButton.addEventListener("click", async () => {
-  const files = selectedFiles();
-  const patchableCount = files.filter(isPatchableJar).length;
-  if (patchableCount === 0) return;
+    const files = selectedFiles();
+    const patchableCount = files.filter(isPatchableJar).length;
+    if (patchableCount === 0 || isBusy) return;
 
-  clearReport();
-  patchButton.disabled = true;
-  fileInput.disabled = true;
+    clearReport();
+    setBusy(true);
+    progress.max = Math.max(files.length, 1);
+    progress.value = 0;
+    progressWrap.hidden = false;
 
-  const results = [];
-  let currentPatchable = 0;
+    const results = [];
+    let currentPatchable = 0;
 
-  try {
-    status.textContent = "Loading Java…";
-    const patcher = await getPatcher();
+    try {
+        status.textContent = "Loading Java runtime…";
+        const patcher = await getPatcher();
 
-    for (let index = 0; index < files.length; index++) {
-      const file = files[index];
+        for (let index = 0; index < files.length; index++) {
+            const file = files[index];
 
-      if (!isJar(file)) {
-        results.push(emptyResult(file.name, "skipped", "Not a .jar file."));
-        renderReport(results, files.length);
-        continue;
-      }
+            if (!isJar(file)) {
+                results.push(emptyResult(file.name, "skipped", "Not a .jar file."));
+                progress.value = index + 1;
+                renderReport(results, files.length);
+                continue;
+            }
 
-      if (isAlreadyPatched(file)) {
-        results.push(emptyResult(file.name, "skipped", "Already patched."));
-        renderReport(results, files.length);
-        continue;
-      }
+            if (isAlreadyPatched(file)) {
+                results.push(emptyResult(file.name, "skipped", "Already patched."));
+                progress.value = index + 1;
+                renderReport(results, files.length);
+                continue;
+            }
 
-      currentPatchable += 1;
-      status.textContent = `Patching ${currentPatchable}/${patchableCount}: ${file.name}`;
+            currentPatchable += 1;
+            status.textContent = `Patching ${currentPatchable}/${patchableCount}: ${file.name}`;
 
-      const safeName = `input-${index}-${sanitizeFileName(file.name)}`;
-      const inputPath = `/str/${safeName}`;
-      const outputPath = `/files/patched-${safeName}`;
+            const safeName = `input-${index}-${sanitizeFileName(file.name)}`;
+            const inputPath = `/str/${safeName}`;
+            const outputPath = `/files/patched-${safeName}`;
 
-      try {
-        const bytes = new Uint8Array(await file.arrayBuffer());
-        cheerpOSAddStringFile(inputPath, bytes);
+            try {
+                const bytes = new Uint8Array(await file.arrayBuffer());
+                cheerpOSAddStringFile(inputPath, bytes);
 
-        const rawReport = await patcher.patch(inputPath);
-        const parsed = parsePatchReport(String(rawReport));
-        const blob = await cjFileBlob(outputPath);
-        const downloadUrl = URL.createObjectURL(blob);
-        objectUrls.push(downloadUrl);
+                const rawReport = await patcher.patch(inputPath);
+                const parsed = parsePatchReport(String(rawReport));
+                const blob = await cjFileBlob(outputPath);
+                const resultUrl = URL.createObjectURL(blob);
+                objectUrls.push(resultUrl);
 
-        results.push({
-          file: file.name,
-          status: parsed.failed > 0 ? "partial" : "success",
-          patched: parsed.patched,
-          skipped: parsed.skipped,
-          failed: parsed.failed,
-          classes: parsed.classes,
-          failures: parsed.failures,
-          error: parsed.failed > 0
-            ? `${parsed.failed} class${parsed.failed === 1 ? " was" : "es were"} left unchanged after a transform error.`
-            : "",
-          downloadUrl,
-          downloadName: `patched-${file.name}`
-        });
+                results.push({
+                    file: file.name,
+                    status: parsed.failed > 0 ? "partial" : "success",
+                    patched: parsed.patched,
+                    skipped: parsed.skipped,
+                    failed: parsed.failed,
+                    classes: parsed.classes,
+                    failures: parsed.failures,
+                    error: parsed.failed > 0
+                        ? `${parsed.failed} class${parsed.failed === 1 ? " was" : "es were"} left unchanged after a transform error.`
+                        : "",
+                    downloadUrl: resultUrl,
+                    downloadName: `patched-${file.name}`
+                });
 
-        try {
-          await patcher.delete(outputPath);
-        } catch (cleanupError) {
-          console.warn("Could not remove temporary output", cleanupError);
+                try {
+                    await patcher.delete(outputPath);
+                } catch (cleanupError) {
+                    console.warn("Could not remove temporary output", cleanupError);
+                }
+            } catch (error) {
+                console.error(error);
+                results.push(emptyResult(file.name, "failed", await errorMessage(error)));
+            } finally {
+                cheerpOSRemoveStringFile(inputPath);
+            }
+
+            progress.value = index + 1;
+            renderReport(results, files.length);
         }
-      } catch (error) {
+
+        const counts = resultCounts(results);
+        status.textContent = `Done. ${counts.success} succeeded, ${counts.partial} partial, ${counts.failed} failed, ${counts.skipped} skipped.`;
+        updateReportDownload(results);
+
+        const downloadable = results.filter(hasOutput);
+        if (downloadable.length === 1 && patchableCount === 1) {
+            const result = downloadable[0];
+            triggerDownload(result.downloadUrl, result.downloadName);
+        }
+    } catch (error) {
         console.error(error);
-        results.push(emptyResult(file.name, "failed", await errorMessage(error)));
-      } finally {
-        cheerpOSRemoveStringFile(inputPath);
-      }
-
-      renderReport(results, files.length);
+        status.textContent = `Error: ${await errorMessage(error)}. You can clear the selection and try again.`;
+    } finally {
+        setBusy(false);
+        progress.value = progress.max;
     }
-
-    const succeeded = results.filter(result => result.status === "success").length;
-    const partial = results.filter(result => result.status === "partial").length;
-    const failed = results.filter(result => result.status === "failed").length;
-    const skipped = results.filter(result => result.status === "skipped").length;
-    status.textContent = `Done. ${succeeded} succeeded, ${partial} partial, ${failed} failed, ${skipped} skipped.`;
-    updateReportDownload(results);
-
-    const downloadable = results.filter(hasOutput);
-    if (downloadable.length === 1 && patchableCount === 1) {
-      const result = downloadable[0];
-      downloadUrl(result.downloadUrl, result.downloadName);
-    }
-  } catch (error) {
-    console.error(error);
-    status.textContent = `Error: ${await errorMessage(error)}`;
-  } finally {
-    fileInput.disabled = false;
-    patchButton.disabled = selectedFiles().filter(isPatchableJar).length === 0;
-  }
 });
 
-async function getPatcher() {
-  if (!patcherPromise) {
-    patcherPromise = (async () => {
-      await cheerpjInit({ version: 17, status: "none" });
+function setSelectedFiles(files) {
+    selectedFileList = uniqueFiles(files);
+    clearReport();
+    renderSelection();
 
-      const jarUrl = new URL("./pasta-web.jar", window.location.href);
-      const libraryPath = `/app${jarUrl.pathname}`;
-      const library = await cheerpjRunLibrary(libraryPath);
-      const WebPatcher = await library.com.patch.foliaphantom.web.WebPatcher;
-      return await new WebPatcher();
-    })().catch(error => {
-      patcherPromise = undefined;
-      throw error;
+    const patchable = selectedFileList.filter(isPatchableJar);
+    const ignored = selectedFileList.length - patchable.length;
+
+    if (selectedFileList.length === 0) {
+        status.textContent = "Select one or more .jar files.";
+    } else if (ignored > 0) {
+        status.textContent = `${patchable.length} ready, ${ignored} will be skipped.`;
+    } else {
+        status.textContent = `${patchable.length} file${patchable.length === 1 ? "" : "s"} ready to patch.`;
+    }
+}
+
+function uniqueFiles(files) {
+    const seen = new Set();
+    return files.filter(file => {
+        const key = `${file.name}\u0000${file.size}\u0000${file.lastModified}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
     });
-  }
-  return patcherPromise;
+}
+
+function renderSelection() {
+    const files = selectedFiles();
+    selectionSection.hidden = files.length === 0;
+    selectionList.replaceChildren(...files.map(createSelectionElement));
+
+    if (files.length > 0) {
+        const patchable = files.filter(isPatchableJar).length;
+        selectionSummary.textContent = `${files.length} selected · ${patchable} ready`;
+    } else {
+        selectionSummary.textContent = "0 files selected";
+    }
+
+    patchButton.disabled = isBusy || files.filter(isPatchableJar).length === 0;
+    clearButton.disabled = isBusy || files.length === 0;
+}
+
+function createSelectionElement(file) {
+    const item = document.createElement("li");
+    item.className = "selection-item";
+
+    const name = document.createElement("span");
+    name.className = "selection-name";
+    name.textContent = file.name;
+
+    const state = document.createElement("span");
+    state.className = "selection-state";
+    if (!isJar(file)) {
+        state.textContent = "Skipped · not a JAR";
+    } else if (isAlreadyPatched(file)) {
+        state.textContent = "Skipped · already patched";
+    } else {
+        state.textContent = `Ready · ${formatBytes(file.size)}`;
+    }
+
+    item.append(name, state);
+    return item;
+}
+
+function setBusy(busy) {
+    isBusy = busy;
+    fileInput.disabled = busy;
+    dropZone.setAttribute("aria-disabled", String(busy));
+    dropZone.classList.remove("is-dragging");
+    renderSelection();
+}
+
+async function getPatcher() {
+    if (!patcherPromise) {
+        patcherPromise = (async () => {
+            await cheerpjInit({ version: 17, status: "none" });
+
+            const jarUrl = new URL("./pasta-web.jar", window.location.href);
+            const libraryPath = `/app${jarUrl.pathname}`;
+            const library = await cheerpjRunLibrary(libraryPath);
+            const WebPatcher = await library.com.patch.foliaphantom.web.WebPatcher;
+            return await new WebPatcher();
+        })().catch(error => {
+            patcherPromise = undefined;
+            throw error;
+        });
+    }
+    return patcherPromise;
 }
 
 function selectedFiles() {
-  return Array.from(fileInput.files ?? []);
+    return selectedFileList;
 }
 
 function isJar(file) {
-  return file.name.toLowerCase().endsWith(".jar");
+    return file.name.toLowerCase().endsWith(".jar");
 }
 
 function isAlreadyPatched(file) {
-  return file.name.toLowerCase().startsWith("patched-");
+    return file.name.toLowerCase().startsWith("patched-");
 }
 
 function isPatchableJar(file) {
-  return isJar(file) && !isAlreadyPatched(file);
+    return isJar(file) && !isAlreadyPatched(file);
 }
 
 function hasOutput(result) {
-  return result.status === "success" || result.status === "partial";
+    return result.status === "success" || result.status === "partial";
 }
 
 function emptyResult(file, resultStatus, error) {
-  return {
-    file,
-    status: resultStatus,
-    patched: 0,
-    skipped: 0,
-    failed: 0,
-    classes: [],
-    failures: [],
-    error
-  };
+    return {
+        file,
+        status: resultStatus,
+        patched: 0,
+        skipped: 0,
+        failed: 0,
+        classes: [],
+        failures: [],
+        error
+    };
 }
 
 function sanitizeFileName(name) {
-  const sanitized = name.replace(/[^a-zA-Z0-9._-]/g, "_");
-  return sanitized || "plugin.jar";
+    const sanitized = name.replace(/[^a-zA-Z0-9._-]/g, "_");
+    return sanitized || "plugin.jar";
+}
+
+function formatBytes(bytes) {
+    if (bytes < 1024) return `${bytes} B`;
+    const units = ["KB", "MB", "GB"];
+    let value = bytes / 1024;
+    let unit = units[0];
+
+    for (let index = 1; index < units.length && value >= 1024; index++) {
+        value /= 1024;
+        unit = units[index];
+    }
+
+    return `${value >= 10 ? value.toFixed(0) : value.toFixed(1)} ${unit}`;
 }
 
 function parsePatchReport(text) {
-  const lines = text.split("\n");
-  const [patchedText = "0", skippedText = "0", failedText = "0"] =
-    (lines.shift() ?? "").split("\t");
-  const classes = [];
-  const failures = [];
+    const lines = text.split("\n");
+    const [patchedText = "0", skippedText = "0", failedText = "0"] =
+        (lines.shift() ?? "").split("\t");
+    const classes = [];
+    const failures = [];
 
-  for (const line of lines) {
-    if (!line) continue;
-    const fields = line.split("\t");
-    const kind = fields.shift();
+    for (const line of lines) {
+        if (!line) continue;
+        const fields = line.split("\t");
+        const kind = fields.shift();
 
-    if (kind === "P" && fields[0]) {
-      classes.push(fields[0]);
-    } else if (kind === "F") {
-      failures.push({
-        className: fields[0] || "unknown class",
-        type: fields[1] || "java.lang.RuntimeException",
-        message: fields.slice(2).join("\t")
-      });
+        if (kind === "P" && fields[0]) {
+            classes.push(fields[0]);
+        } else if (kind === "F") {
+            failures.push({
+                className: fields[0] || "unknown class",
+                type: fields[1] || "java.lang.RuntimeException",
+                message: fields.slice(2).join("\t")
+            });
+        }
     }
-  }
 
-  return {
-    patched: Number.parseInt(patchedText, 10) || 0,
-    skipped: Number.parseInt(skippedText, 10) || 0,
-    failed: Number.parseInt(failedText, 10) || failures.length,
-    classes,
-    failures
-  };
+    return {
+        patched: Number.parseInt(patchedText, 10) || 0,
+        skipped: Number.parseInt(skippedText, 10) || 0,
+        failed: Number.parseInt(failedText, 10) || failures.length,
+        classes,
+        failures
+    };
+}
+
+function resultCounts(results) {
+    return {
+        success: results.filter(result => result.status === "success").length,
+        partial: results.filter(result => result.status === "partial").length,
+        failed: results.filter(result => result.status === "failed").length,
+        skipped: results.filter(result => result.status === "skipped").length
+    };
 }
 
 function renderReport(results, total) {
-  reportSection.hidden = false;
-  resultsContainer.replaceChildren(...results.map(createResultElement));
+    reportSection.hidden = false;
+    resultsContainer.replaceChildren(...results.map(createResultElement));
 
-  const succeeded = results.filter(result => result.status === "success").length;
-  const partial = results.filter(result => result.status === "partial").length;
-  const failed = results.filter(result => result.status === "failed").length;
-  const skipped = results.filter(result => result.status === "skipped").length;
-  reportSummary.textContent = `${results.length}/${total} processed · ${succeeded} success · ${partial} partial · ${failed} failed · ${skipped} skipped`;
+    const counts = resultCounts(results);
+    reportSummary.textContent = `${results.length}/${total} processed · ${counts.success} success · ${counts.partial} partial · ${counts.failed} failed · ${counts.skipped} skipped`;
 }
 
 function createResultElement(result) {
-  const article = document.createElement("article");
-  article.className = "result";
+    const article = document.createElement("article");
+    article.className = "result";
 
-  const head = document.createElement("div");
-  head.className = "result-head";
+    const head = document.createElement("div");
+    head.className = "result-head";
 
-  const name = document.createElement("strong");
-  name.className = "result-name";
-  name.textContent = result.file;
+    const name = document.createElement("strong");
+    name.className = "result-name";
+    name.textContent = result.file;
 
-  const meta = document.createElement("span");
-  meta.className = "result-meta";
-  meta.textContent = hasOutput(result)
-    ? `${result.patched} patched / ${result.skipped} skipped / ${result.failed} unchanged`
-    : result.status;
+    const meta = document.createElement("span");
+    meta.className = "result-meta";
+    meta.textContent = hasOutput(result)
+        ? `${result.patched} patched / ${result.skipped} skipped / ${result.failed} unchanged`
+        : result.status;
 
-  head.append(name, meta);
-  article.append(head);
+    head.append(name, meta);
+    article.append(head);
 
-  if (result.error) {
-    const error = document.createElement("div");
-    error.className = "result-error";
-    error.textContent = result.error;
-    article.append(error);
-  }
-
-  if (hasOutput(result)) {
-    const links = document.createElement("div");
-    links.className = "links";
-
-    const download = document.createElement("a");
-    download.href = result.downloadUrl;
-    download.download = result.downloadName;
-    download.textContent = "Download JAR";
-    links.append(download);
-    article.append(links);
-
-    if (result.classes.length > 0) {
-      const details = document.createElement("details");
-      const summary = document.createElement("summary");
-      summary.textContent = `${result.classes.length} patched classes`;
-      const pre = document.createElement("pre");
-      pre.textContent = result.classes.join("\n");
-      details.append(summary, pre);
-      article.append(details);
+    if (result.error) {
+        const error = document.createElement("div");
+        error.className = "result-error";
+        error.textContent = result.error;
+        article.append(error);
     }
 
-    if (result.failures.length > 0) {
-      const details = document.createElement("details");
-      const summary = document.createElement("summary");
-      summary.textContent = `${result.failures.length} unchanged classes`;
-      const pre = document.createElement("pre");
-      pre.textContent = result.failures.map(formatFailure).join("\n");
-      details.append(summary, pre);
-      article.append(details);
-    }
-  }
+    if (hasOutput(result)) {
+        const links = document.createElement("div");
+        links.className = "links";
 
-  return article;
+        const download = document.createElement("a");
+        download.href = result.downloadUrl;
+        download.download = result.downloadName;
+        download.textContent = "Download JAR";
+        links.append(download);
+        article.append(links);
+
+        if (result.classes.length > 0) {
+            const details = document.createElement("details");
+            const summary = document.createElement("summary");
+            summary.textContent = `${result.classes.length} patched classes`;
+            const pre = document.createElement("pre");
+            pre.textContent = result.classes.join("\n");
+            details.append(summary, pre);
+            article.append(details);
+        }
+
+        if (result.failures.length > 0) {
+            const details = document.createElement("details");
+            const summary = document.createElement("summary");
+            summary.textContent = `${result.failures.length} unchanged classes`;
+            const pre = document.createElement("pre");
+            pre.textContent = result.failures.map(formatFailure).join("\n");
+            details.append(summary, pre);
+            article.append(details);
+        }
+    }
+
+    return article;
 }
 
 function formatFailure(failure) {
-  const detail = failure.message ? `: ${failure.message}` : "";
-  return `${failure.className} — ${failure.type}${detail}`;
+    const detail = failure.message ? `: ${failure.message}` : "";
+    return `${failure.className} — ${failure.type}${detail}`;
 }
 
 function updateReportDownload(results) {
-  const rows = [
-    [
-      "file",
-      "status",
-      "patched_classes",
-      "skipped_classes",
-      "unchanged_classes",
-      "patched_class_names",
-      "unchanged_class_details",
-      "error"
-    ],
-    ...results.map(result => [
-      result.file,
-      result.status,
-      result.patched,
-      result.skipped,
-      result.failed,
-      result.classes.join(";"),
-      result.failures.map(formatFailure).join(";"),
-      result.error
-    ])
-  ];
+    const rows = [
+        [
+            "file",
+            "status",
+            "patched_classes",
+            "skipped_classes",
+            "unchanged_classes",
+            "patched_class_names",
+            "unchanged_class_details",
+            "error"
+        ],
+        ...results.map(result => [
+            result.file,
+            result.status,
+            result.patched,
+            result.skipped,
+            result.failed,
+            result.classes.join(";"),
+            result.failures.map(formatFailure).join(";"),
+            result.error
+        ])
+    ];
 
-  const csv = rows.map(row => row.map(csvCell).join(",")).join("\r\n");
-  const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
-  const url = URL.createObjectURL(blob);
-  objectUrls.push(url);
-  reportDownload.href = url;
-  reportDownload.hidden = false;
+    const csv = rows.map(row => row.map(csvCell).join(",")).join("\r\n");
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    objectUrls.push(url);
+    reportDownload.href = url;
+    reportDownload.hidden = false;
 }
 
 function csvCell(value) {
-  const text = String(value ?? "");
-  return `"${text.replaceAll('"', '""')}"`;
+    const text = String(value ?? "");
+    return `"${text.replaceAll('"', '""')}"`;
 }
 
-function downloadUrl(url, fileName) {
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = fileName;
-  document.body.appendChild(link);
-  link.click();
-  link.remove();
+function triggerDownload(url, fileName) {
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
 }
 
 function clearReport() {
-  for (const url of objectUrls) URL.revokeObjectURL(url);
-  objectUrls = [];
-  resultsContainer.replaceChildren();
-  reportSummary.textContent = "";
-  reportDownload.removeAttribute("href");
-  reportDownload.hidden = true;
-  reportSection.hidden = true;
+    for (const url of objectUrls) URL.revokeObjectURL(url);
+    objectUrls = [];
+    resultsContainer.replaceChildren();
+    reportSummary.textContent = "";
+    reportDownload.removeAttribute("href");
+    reportDownload.hidden = true;
+    reportSection.hidden = true;
+    progress.value = 0;
+    progressWrap.hidden = true;
 }
 
 async function errorMessage(error) {
-  const parts = [];
-  let current = error;
+    const parts = [];
+    let current = error;
 
-  for (let depth = 0; depth < 4 && current; depth++) {
-    const name = await throwableName(current);
-    const message = await throwableMessage(current);
-    const typeName = await missingTypeName(current);
-    const detail = message || typeName;
-    const part = [name, detail].filter(Boolean).join(": ");
-    if (part && !parts.includes(part)) parts.push(part);
+    for (let depth = 0; depth < 4 && current; depth++) {
+        const name = await throwableName(current);
+        const message = await throwableMessage(current);
+        const typeName = await missingTypeName(current);
+        const detail = message || typeName;
+        const part = [name, detail].filter(Boolean).join(": ");
+        if (part && !parts.includes(part)) parts.push(part);
 
-    try {
-      current = typeof current?.getCause === "function"
-        ? await current.getCause()
-        : null;
-    } catch {
-      current = null;
+        try {
+            current = typeof current?.getCause === "function"
+                ? await current.getCause()
+                : null;
+        } catch {
+            current = null;
+        }
     }
-  }
 
-  return parts.join(" → ") || error?.message || String(error);
+    return parts.join(" → ") || error?.message || String(error);
 }
 
 async function throwableName(error) {
-  try {
-    if (typeof error?.getClass === "function") {
-      const clazz = await error.getClass();
-      if (clazz && typeof clazz.getName === "function") {
-        return String(await clazz.getName());
-      }
+    try {
+        if (typeof error?.getClass === "function") {
+            const clazz = await error.getClass();
+            if (clazz && typeof clazz.getName === "function") {
+                return String(await clazz.getName());
+            }
+        }
+    } catch {
+        // Fall through to the JavaScript name.
     }
-  } catch {
-    // Fall through to the JavaScript name.
-  }
-  return error?.name || "";
+    return error?.name || "";
 }
 
 async function throwableMessage(error) {
-  try {
-    if (typeof error?.getMessage === "function") {
-      const message = await error.getMessage();
-      if (message) return String(message);
+    try {
+        if (typeof error?.getMessage === "function") {
+            const message = await error.getMessage();
+            if (message) return String(message);
+        }
+    } catch {
+        // Fall through to the JavaScript message.
     }
-  } catch {
-    // Fall through to the JavaScript message.
-  }
-  return error?.message || "";
+    return error?.message || "";
 }
 
 async function missingTypeName(error) {
-  try {
-    if (typeof error?.typeName === "function") {
-      const value = await error.typeName();
-      return value ? `missing type ${String(value)}` : "";
+    try {
+        if (typeof error?.typeName === "function") {
+            const value = await error.typeName();
+            return value ? `missing type ${String(value)}` : "";
+        }
+    } catch {
+        // Not a TypeNotPresentException.
     }
-  } catch {
-    // Not a TypeNotPresentException.
-  }
-  return "";
+    return "";
 }

--- a/web/index.html
+++ b/web/index.html
@@ -1,86 +1,267 @@
 <!doctype html>
-<html lang="ja">
+<html lang="en">
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>pasta</title>
-  <meta name="description" content="Patch Bukkit plugins for Folia in your browser.">
-  <link rel="icon" href="data:,">
-  <script src="https://cjrtnc.leaningtech.com/4.3/loader.js"></script>
-  <style>
-    * { box-sizing: border-box; }
-    body {
-      margin: 0;
-      min-height: 100vh;
-      display: grid;
-      place-items: center;
-      padding: 24px;
-      font: 15px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      color: #111;
-      background: #fff;
-    }
-    main { width: min(100%, 720px); }
-    h1 { margin: 0 0 8px; font-size: 28px; }
-    p { margin: 0 0 24px; color: #666; }
-    input { width: 100%; margin-bottom: 12px; }
-    button {
-      width: 100%;
-      padding: 12px 16px;
-      border: 1px solid #111;
-      border-radius: 6px;
-      background: #111;
-      color: #fff;
-      font: inherit;
-      cursor: pointer;
-    }
-    button:disabled { opacity: .45; cursor: default; }
-    #status { min-height: 24px; margin: 14px 0 0; color: #666; }
-    #report { margin-top: 24px; }
-    #report[hidden] { display: none; }
-    .summary { margin-bottom: 12px; color: #444; }
-    .result {
-      padding: 12px 0;
-      border-top: 1px solid #ddd;
-    }
-    .result:last-of-type { border-bottom: 1px solid #ddd; }
-    .result-head {
-      display: flex;
-      gap: 12px;
-      justify-content: space-between;
-      align-items: baseline;
-    }
-    .result-name { overflow-wrap: anywhere; }
-    .result-meta { color: #666; white-space: nowrap; }
-    .result-error { margin-top: 6px; color: #900; overflow-wrap: anywhere; }
-    .links { display: flex; gap: 14px; margin-top: 8px; }
-    .links a, #report-download { color: inherit; }
-    details { margin-top: 8px; color: #555; }
-    pre { margin: 8px 0 0; white-space: pre-wrap; overflow-wrap: anywhere; font: inherit; }
-    #report-download { display: inline-block; margin-top: 14px; }
-    footer { margin-top: 28px; font-size: 12px; color: #888; }
-    a { color: inherit; }
-  </style>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#111111">
+    <title>pasta — Bukkit to Folia patcher</title>
+    <meta name="description" content="Patch Bukkit plugin JARs for Folia locally in your browser.">
+    <link rel="icon" href="data:,">
+    <script src="https://cjrtnc.leaningtech.com/4.3/loader.js"></script>
+    <style>
+        * { box-sizing: border-box; }
+        :root {
+            color-scheme: light dark;
+            font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            padding: 32px 20px;
+            color: #171717;
+            background: #f7f7f5;
+        }
+        main { width: min(100%, 820px); margin: 0 auto; }
+        h1 { margin: 0; font-size: clamp(32px, 8vw, 54px); line-height: 1; letter-spacing: -0.06em; }
+        h2 { margin: 0 0 8px; font-size: 18px; }
+        p { margin: 0; color: #666; }
+        a { color: inherit; }
+        button, input { font: inherit; }
+        button:focus-visible, a:focus-visible, [tabindex]:focus-visible {
+            outline: 3px solid currentColor;
+            outline-offset: 3px;
+        }
+        .eyebrow {
+            margin-bottom: 12px;
+            color: #555;
+            font-size: 12px;
+            letter-spacing: .08em;
+            text-transform: uppercase;
+        }
+        .lede { margin-top: 14px; max-width: 66ch; font-size: 16px; }
+        .privacy {
+            display: inline-flex;
+            gap: 8px;
+            align-items: center;
+            margin-top: 18px;
+            padding: 7px 10px;
+            border: 1px solid #d2d2cc;
+            border-radius: 999px;
+            font-size: 12px;
+            color: #4d4d4d;
+            background: #fff;
+        }
+        .privacy::before {
+            content: "";
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: #27863b;
+        }
+        .panel {
+            margin-top: 28px;
+            padding: 22px;
+            border: 1px solid #d2d2cc;
+            border-radius: 14px;
+            background: #fff;
+        }
+        .drop-zone {
+            display: grid;
+            place-items: center;
+            min-height: 170px;
+            padding: 28px;
+            border: 2px dashed #b7b7b0;
+            border-radius: 12px;
+            text-align: center;
+            cursor: pointer;
+            transition: border-color .15s ease, background .15s ease, transform .15s ease;
+        }
+        .drop-zone:hover, .drop-zone.is-dragging {
+            border-color: #111;
+            background: #f4f4f0;
+        }
+        .drop-zone.is-dragging { transform: scale(1.005); }
+        .drop-zone[aria-disabled="true"] { opacity: .55; cursor: default; }
+        .drop-title { display: block; color: #111; font-weight: 700; font-size: 17px; }
+        .drop-hint { display: block; margin-top: 7px; color: #777; font-size: 13px; }
+        .visually-hidden {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+        }
+        .selection { margin-top: 18px; }
+        .selection-head {
+            display: flex;
+            justify-content: space-between;
+            gap: 14px;
+            align-items: baseline;
+        }
+        .selection-list {
+            display: grid;
+            gap: 7px;
+            margin: 10px 0 0;
+            padding: 0;
+            list-style: none;
+        }
+        .selection-item {
+            display: flex;
+            justify-content: space-between;
+            gap: 14px;
+            padding: 9px 11px;
+            border-radius: 8px;
+            background: #f5f5f2;
+            font-size: 13px;
+        }
+        .selection-name { min-width: 0; overflow-wrap: anywhere; }
+        .selection-state { color: #666; white-space: nowrap; }
+        .actions {
+            display: grid;
+            grid-template-columns: minmax(0, 1fr) auto;
+            gap: 10px;
+            margin-top: 18px;
+        }
+        button {
+            min-height: 44px;
+            padding: 10px 16px;
+            border: 1px solid #111;
+            border-radius: 8px;
+            background: #111;
+            color: #fff;
+            cursor: pointer;
+        }
+        button.secondary { background: transparent; color: #111; }
+        button:disabled { opacity: .4; cursor: default; }
+        .progress-wrap { margin-top: 16px; }
+        progress { width: 100%; height: 8px; accent-color: #111; }
+        #status { min-height: 24px; margin-top: 10px; color: #666; }
+        #report { margin-top: 28px; }
+        #report[hidden], .selection[hidden], .progress-wrap[hidden] { display: none; }
+        .summary { margin-bottom: 12px; color: #444; }
+        .result { padding: 14px 0; border-top: 1px solid #ddd; }
+        .result:last-of-type { border-bottom: 1px solid #ddd; }
+        .result-head {
+            display: flex;
+            gap: 12px;
+            justify-content: space-between;
+            align-items: baseline;
+        }
+        .result-name { overflow-wrap: anywhere; }
+        .result-meta { color: #666; white-space: nowrap; font-size: 12px; }
+        .result-error { margin-top: 7px; color: #8b1a1a; overflow-wrap: anywhere; }
+        .links { display: flex; gap: 14px; margin-top: 9px; }
+        .links a, #report-download { font-weight: 700; }
+        details { margin-top: 9px; color: #555; }
+        pre { margin: 8px 0 0; white-space: pre-wrap; overflow-wrap: anywhere; font: inherit; }
+        #report-download { display: inline-block; margin-top: 16px; }
+        .modes {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 10px;
+            margin-top: 14px;
+        }
+        .mode {
+            padding: 14px;
+            border: 1px solid #ddd;
+            border-radius: 10px;
+            color: #555;
+            font-size: 12px;
+        }
+        .mode strong { display: block; margin-bottom: 5px; color: #222; font-size: 13px; }
+        footer { margin-top: 28px; font-size: 12px; color: #777; }
+        @media (max-width: 640px) {
+            body { padding: 24px 14px; }
+            .panel { padding: 16px; }
+            .actions { grid-template-columns: 1fr; }
+            .modes { grid-template-columns: 1fr; }
+            .result-head, .selection-item { align-items: flex-start; flex-direction: column; gap: 4px; }
+            .result-meta, .selection-state { white-space: normal; }
+        }
+        @media (prefers-reduced-motion: reduce) {
+            .drop-zone { transition: none; }
+        }
+        @media (prefers-color-scheme: dark) {
+            body { color: #ededed; background: #111; }
+            p, #status, .drop-hint, .selection-state, .result-meta, footer { color: #aaa; }
+            .privacy, .panel { background: #181818; border-color: #3c3c3c; color: #ccc; }
+            .drop-zone { border-color: #555; }
+            .drop-zone:hover, .drop-zone.is-dragging { border-color: #eee; background: #222; }
+            .drop-title, .mode strong { color: #eee; }
+            .selection-item { background: #242424; }
+            .mode, .result { border-color: #3c3c3c; }
+            .mode, details, .summary { color: #bbb; }
+            button { border-color: #eee; background: #eee; color: #111; }
+            button.secondary { background: transparent; color: #eee; }
+            progress { accent-color: #eee; }
+        }
+    </style>
 </head>
 <body>
-  <main>
-    <h1>pasta</h1>
-    <p>Bukkit plugin → Folia</p>
+    <main>
+        <header>
+            <div class="eyebrow">Carbonara update</div>
+            <h1>pasta</h1>
+            <p class="lede">Convert Bukkit plugin JARs for Folia without installing a desktop app. Pick files, patch locally, then download the results.</p>
+            <div class="privacy">Runs locally in your browser — plugin JARs are not uploaded to pasta.</div>
+        </header>
 
-    <input id="file" type="file" multiple accept=".jar,application/java-archive">
-    <button id="patch" disabled>Patch selected</button>
-    <div id="status">Select one or more .jar files.</div>
+        <section class="panel" aria-labelledby="patch-heading">
+            <h2 id="patch-heading">Patch plugins</h2>
+            <p>Choose one or more <code>.jar</code> files. Files named <code>patched-*.jar</code> are skipped to avoid accidental double-patching.</p>
 
-    <section id="report" hidden aria-live="polite">
-      <div id="report-summary" class="summary"></div>
-      <div id="results"></div>
-      <a id="report-download" download="pasta-report.csv">Download report.csv</a>
-    </section>
+            <input id="file" class="visually-hidden" type="file" multiple accept=".jar,application/java-archive">
+            <div id="drop-zone" class="drop-zone" role="button" tabindex="0" aria-controls="file" aria-describedby="drop-hint">
+                <span>
+                    <span class="drop-title">Drop plugin JARs here</span>
+                    <span id="drop-hint" class="drop-hint">or press Enter / click to browse</span>
+                </span>
+            </div>
 
-    <footer>
-      Runs locally in your browser with CheerpJ. Your plugin JARs are not uploaded to pasta.
-    </footer>
-  </main>
+            <section id="selection" class="selection" hidden aria-live="polite">
+                <div class="selection-head">
+                    <strong id="selection-summary">0 files selected</strong>
+                </div>
+                <ul id="selection-list" class="selection-list"></ul>
+            </section>
 
-  <script type="module" src="./app.js"></script>
+            <div class="actions">
+                <button id="patch" disabled>Patch selected JARs</button>
+                <button id="clear" class="secondary" disabled>Clear</button>
+            </div>
+
+            <div id="progress-wrap" class="progress-wrap" hidden>
+                <progress id="progress" value="0" max="1"></progress>
+            </div>
+            <div id="status" role="status" aria-live="polite">Select one or more .jar files.</div>
+
+            <section id="report" hidden aria-live="polite">
+                <div id="report-summary" class="summary"></div>
+                <div id="results"></div>
+                <a id="report-download" download="pasta-report.csv">Download report.csv</a>
+            </section>
+        </section>
+
+        <section class="panel" aria-labelledby="other-ways-heading">
+            <h2 id="other-ways-heading">Other ways to run pasta</h2>
+            <p>The same project also provides local CLI, desktop GUI, and server-side plugin workflows.</p>
+            <div class="modes">
+                <div class="mode"><strong>CLI</strong>Batch patch a JAR or directory from a terminal.</div>
+                <div class="mode"><strong>Desktop</strong>Use the JavaFX application for drag-and-drop workflows.</div>
+                <div class="mode"><strong>Server plugin</strong>Patch installed plugins from Bukkit/Paper commands.</div>
+            </div>
+        </section>
+
+        <footer>
+            Browser execution is powered by CheerpJ. Review the project source and usage instructions on
+            <a href="https://github.com/MARVserver/pasta">GitHub</a>.
+        </footer>
+    </main>
+
+    <script type="module" src="./app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Problem

pasta's core patching capabilities are present, but contributor guidance is implicit and the browser/CLI workflows expose avoidable friction.

## Changes

- add `AGENTS.md` with repository architecture, Java/Folia/ASM invariants, web privacy rules, and verification expectations
- add `CONTRIBUTING.md` and `.editorconfig`
- redesign the static browser flow with drag-and-drop, selected-file visibility, progress, reset controls, responsive/dark-mode handling, and stronger accessibility
- keep browser patching local; no upload/telemetry path is introduced
- add CLI `--help`, `--output`, `--no-banner`, `--` handling, case-insensitive JAR checks, deterministic directory ordering, and already-patched filtering
- update README with the Carbonara scope, browser workflow, CLI options, five-module layout, and current transformer chain
- align CI with the actual Paper 1.21.x toolchain: Maven runs on JDK 21 while pasta-owned classes remain configured for `--release 17`
- keep dependency review visible but non-blocking until the repository's GitHub Dependency graph is enabled

## Compatibility

- Maven build JDK is 21+ because Paper API 1.21.1 contains Java 21 class files
- pasta's configured emitted bytecode target remains release 17; changing that target is a separate browser/runtime compatibility decision
- project version remains 2.0.0; Carbonara is a development codename, not a release bump
- existing `java -jar ... <jar|directory>` and no-argument interactive CLI workflows remain supported

## Verification

Final CI run #39 completed successfully:

- Java 21 Maven reactor verification: success
- packaged artifact upload: success
- dependency-review job: success (the review action itself remains advisory while GitHub Dependency graph is disabled)
- CodeQL build and analysis: success

The earlier Java 17 lane exposed an existing toolchain mismatch: Paper API 1.21.1 classes are Java 21 bytecode. The workflow and contributor documentation now use JDK 21 for builds while preserving pasta's configured `--release 17` output target.

Browser changes should also be manually exercised for picker/drop, skip, progress, download, and clear states before merge.