### PR TITLE
fix: support BukkitRunnable super scheduling calls

### DIFF
--- a/folia-phantom/folia-phantom-core/pom.xml
+++ b/folia-phantom/folia-phantom-core/pom.xml
@@ -44,5 +44,11 @@
             <artifactId>slf4j-api</artifactId>
             <version>2.0.9</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/transformer/SchedulerClassTransformer.java
+++ b/folia-phantom/folia-phantom-core/src/main/java/com/patch/foliaphantom/transformer/SchedulerClassTransformer.java
@@ -4,8 +4,18 @@ import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.FieldNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.JumpInsnNode;
+import org.objectweb.asm.tree.LabelNode;
+import org.objectweb.asm.tree.LdcInsnNode;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.TypeInsnNode;
+import org.objectweb.asm.tree.VarInsnNode;
+
 import java.util.List;
 
 /**
@@ -28,11 +38,30 @@ import java.util.List;
  *   <li>{@code BukkitRunnable.runTaskTimerAsynchronously(plugin, delay, period)} → {@code FoliaPatcher.runTaskTimerAsynchronously_onRunnable(runnable, plugin, delay, period)}</li>
  * </ul>
  * </p>
+ *
+ * <p>{@code super.runTask*()} は JVM 上で {@code INVOKESPECIAL} になる。通常の
+ * {@code INVOKEVIRTUAL} 呼び出しと同様に変換しつつ、元の {@code BukkitRunnable}
+ * が保持していたタスク状態をサブクラス側に保存する。これにより eco の
+ * {@code EcoRunnableTask} のようなラッパーでも {@code cancel()},
+ * {@code isCancelled()}, {@code getTaskId()} が legacy {@code BukkitScheduler}
+ * に戻らず動作する。</p>
  */
 public final class SchedulerClassTransformer implements ClassTransformer, Opcodes {
 
     /** BukkitScheduler の内部名 */
     private static final String BUKKIT_SCHEDULER_OWNER = "org/bukkit/scheduler/BukkitScheduler";
+
+    /** BukkitRunnable の内部名 */
+    private static final String BUKKIT_RUNNABLE_OWNER = "org/bukkit/scheduler/BukkitRunnable";
+
+    /** BukkitTask の内部名 */
+    private static final String BUKKIT_TASK_OWNER = "org/bukkit/scheduler/BukkitTask";
+
+    /** BukkitTask の descriptor */
+    private static final String BUKKIT_TASK_DESC = "Lorg/bukkit/scheduler/BukkitTask;";
+
+    /** super.runTask*() 変換時にサブクラスへ追加するタスク状態フィールド */
+    private static final String RUNNABLE_TASK_FIELD = "__pastaBukkitTask";
 
     /** FoliaPatcher の内部名 */
     private static final String PATCHER_OWNER = "com/patch/foliaphantom/patcher/FoliaPatcher";
@@ -84,9 +113,17 @@ public final class SchedulerClassTransformer implements ClassTransformer, Opcode
             classNode.accept(writer);
             return writer.toByteArray();
         }
+
+        boolean needsRunnableState = false;
         for (MethodNode method : methods) {
-            transformMethod(method);
+            if (transformMethod(classNode, method)) {
+                needsRunnableState = true;
+            }
         }
+        if (needsRunnableState) {
+            ensureRunnableStateMembers(classNode);
+        }
+
         classNode.accept(writer);
         return writer.toByteArray();
     }
@@ -94,16 +131,22 @@ public final class SchedulerClassTransformer implements ClassTransformer, Opcode
     /**
      * 単一メソッド内のスケジューラ呼び出しを置き換える。
      *
+     * @param classNode 変換対象クラス
      * @param method 変換対象のメソッドノード
+     * @return BukkitRunnable の super 呼び出しを変換した場合 true
      */
-    private void transformMethod(MethodNode method) {
+    private boolean transformMethod(ClassNode classNode, MethodNode method) {
+        boolean transformedSuperCall = false;
         AbstractInsnNode[] insns = method.instructions.toArray();
         for (AbstractInsnNode insn : insns) {
             if (insn instanceof MethodInsnNode methodInsn) {
                 replaceSchedulerCall(methodInsn);
-                replaceBukkitRunnableCall(methodInsn);
+                if (replaceBukkitRunnableCall(method, methodInsn, classNode.name)) {
+                    transformedSuperCall = true;
+                }
             }
         }
+        return transformedSuperCall;
     }
 
     /**
@@ -120,7 +163,7 @@ public final class SchedulerClassTransformer implements ClassTransformer, Opcode
         }
         // 通常のスケジューラメソッド: 第1引数に BukkitScheduler インスタンスを追加
         methodInsn.owner = PATCHER_OWNER;
-        methodInsn.desc = "(Lorg/bukkit/scheduler/BukkitScheduler;" 
+        methodInsn.desc = "(Lorg/bukkit/scheduler/BukkitScheduler;"
                 + methodInsn.desc.substring(1);
         methodInsn.setOpcode(INVOKESTATIC);
         methodInsn.itf = false;
@@ -130,25 +173,39 @@ public final class SchedulerClassTransformer implements ClassTransformer, Opcode
      * BukkitRunnable のインスタンスメソッド呼び出しを
      * FoliaPatcher の静的メソッドに置き換える。
      *
-     * <p>BukkitRunnable のサブクラス経由の呼び出しでは owner がサブクラス名になるため
-     * owner チェックは行わない。代わりに BukkitRunnable のメソッドシグネチャ先頭が
+     * <p>通常の {@code INVOKEVIRTUAL} では BukkitRunnable のサブクラス経由の
+     * 呼び出しで owner がサブクラス名になるため owner チェックは行わない。
+     * 代わりに BukkitRunnable のメソッドシグネチャ先頭が
      * {@code (Lorg/bukkit/plugin/Plugin;} であることを確認して偽陽性を排除する。</p>
      *
+     * <p>{@code INVOKESPECIAL} は {@code super.runTask*()} のときだけ対象とし、
+     * owner が {@code BukkitRunnable} と完全一致する場合に限定する。変換後の
+     * BukkitTask はサブクラスへ追加する synthetic field に保存する。</p>
+     *
+     * @param method 変換対象メソッド
      * @param methodInsn 検査対象のメソッド呼び出しノード
+     * @param className 現在のクラス内部名
+     * @return super 呼び出しを変換した場合 true
      */
-    private void replaceBukkitRunnableCall(MethodInsnNode methodInsn) {
-        // INVOKEVIRTUAL 以外は BukkitRunnable インスタンスメソッドではない
-        if (methodInsn.getOpcode() != INVOKEVIRTUAL) {
-            return;
+    private boolean replaceBukkitRunnableCall(
+            MethodNode method, MethodInsnNode methodInsn, String className) {
+        int originalOpcode = methodInsn.getOpcode();
+        boolean isVirtualCall = originalOpcode == INVOKEVIRTUAL;
+        boolean isSuperCall = originalOpcode == INVOKESPECIAL
+                && BUKKIT_RUNNABLE_OWNER.equals(methodInsn.owner);
+
+        if (!isVirtualCall && !isSuperCall) {
+            return false;
         }
         if (!isRunnableInstanceMethod(methodInsn.name)) {
-            return;
+            return false;
         }
         // BukkitRunnable メソッドの第一引数は必ず Plugin。
         // 別クラスに同名メソッドがある場合の偽陽性を排除する。
         if (!methodInsn.desc.startsWith("(Lorg/bukkit/plugin/Plugin;")) {
-            return;
+            return false;
         }
+
         // desc の先頭に Runnable 引数を追加: (Lplugin;...) → (Lrunnable;Lplugin;...)
         String newName = methodInsn.name + "_onRunnable";
         String newDesc = "(Ljava/lang/Runnable;" + methodInsn.desc.substring(1);
@@ -157,6 +214,125 @@ public final class SchedulerClassTransformer implements ClassTransformer, Opcode
         methodInsn.desc = newDesc;
         methodInsn.setOpcode(INVOKESTATIC);
         methodInsn.itf = false;
+
+        if (isSuperCall) {
+            storeSuperCallTask(method, methodInsn, className);
+        }
+        return isSuperCall;
+    }
+
+    /**
+     * 変換済み super.runTask*() の戻り値をサブクラス側へ保存する。
+     * 呼び出し結果は元コード向けにスタック上へ残す。
+     */
+    private void storeSuperCallTask(MethodNode method, MethodInsnNode methodInsn, String className) {
+        InsnList store = new InsnList();
+        store.add(new InsnNode(DUP));
+        store.add(new VarInsnNode(ALOAD, 0));
+        store.add(new InsnNode(SWAP));
+        store.add(new FieldInsnNode(
+                PUTFIELD, className, RUNNABLE_TASK_FIELD, BUKKIT_TASK_DESC));
+        method.instructions.insert(methodInsn, store);
+    }
+
+    /**
+     * BukkitRunnable が通常提供するタスク状態 API をサブクラス側で再現する。
+     *
+     * <p>元の BukkitRunnable.cancel() は Bukkit.getScheduler().cancelTask(...) を
+     * 呼ぶため Folia では利用できない。FoliaPatcher が返す BukkitTask を直接
+     * 操作する override を注入する。</p>
+     */
+    private void ensureRunnableStateMembers(ClassNode classNode) {
+        if (!hasField(classNode, RUNNABLE_TASK_FIELD)) {
+            classNode.fields.add(new FieldNode(
+                    ACC_PRIVATE | ACC_TRANSIENT | ACC_SYNTHETIC,
+                    RUNNABLE_TASK_FIELD,
+                    BUKKIT_TASK_DESC,
+                    null,
+                    null));
+        }
+        if (!hasMethod(classNode, "cancel", "()V")) {
+            classNode.methods.add(createCancelMethod(classNode.name));
+        }
+        if (!hasMethod(classNode, "isCancelled", "()Z")) {
+            classNode.methods.add(createTaskStateMethod(
+                    classNode.name, "isCancelled", "()Z", IRETURN));
+        }
+        if (!hasMethod(classNode, "getTaskId", "()I")) {
+            classNode.methods.add(createTaskStateMethod(
+                    classNode.name, "getTaskId", "()I", IRETURN));
+        }
+    }
+
+    private MethodNode createCancelMethod(String className) {
+        MethodNode method = new MethodNode(
+                ASM9,
+                ACC_PUBLIC | ACC_SYNCHRONIZED | ACC_SYNTHETIC,
+                "cancel",
+                "()V",
+                null,
+                null);
+        appendLoadedTaskOrThrow(method.instructions, className);
+        method.instructions.add(new MethodInsnNode(
+                INVOKEINTERFACE, BUKKIT_TASK_OWNER, "cancel", "()V", true));
+        method.instructions.add(new InsnNode(RETURN));
+        return method;
+    }
+
+    private MethodNode createTaskStateMethod(
+            String className, String name, String descriptor, int returnOpcode) {
+        MethodNode method = new MethodNode(
+                ASM9,
+                ACC_PUBLIC | ACC_SYNCHRONIZED | ACC_SYNTHETIC,
+                name,
+                descriptor,
+                null,
+                null);
+        appendLoadedTaskOrThrow(method.instructions, className);
+        method.instructions.add(new MethodInsnNode(
+                INVOKEINTERFACE, BUKKIT_TASK_OWNER, name, descriptor, true));
+        method.instructions.add(new InsnNode(returnOpcode));
+        return method;
+    }
+
+    /** スタックへ保存済み BukkitTask を積み、未スケジュールなら例外を投げる。 */
+    private void appendLoadedTaskOrThrow(InsnList instructions, String className) {
+        LabelNode scheduled = new LabelNode();
+        instructions.add(new VarInsnNode(ALOAD, 0));
+        instructions.add(new FieldInsnNode(
+                GETFIELD, className, RUNNABLE_TASK_FIELD, BUKKIT_TASK_DESC));
+        instructions.add(new InsnNode(DUP));
+        instructions.add(new JumpInsnNode(IFNONNULL, scheduled));
+        instructions.add(new InsnNode(POP));
+        instructions.add(new TypeInsnNode(NEW, "java/lang/IllegalStateException"));
+        instructions.add(new InsnNode(DUP));
+        instructions.add(new LdcInsnNode("Not scheduled yet"));
+        instructions.add(new MethodInsnNode(
+                INVOKESPECIAL,
+                "java/lang/IllegalStateException",
+                "<init>",
+                "(Ljava/lang/String;)V",
+                false));
+        instructions.add(new InsnNode(ATHROW));
+        instructions.add(scheduled);
+    }
+
+    private static boolean hasField(ClassNode classNode, String name) {
+        for (FieldNode field : classNode.fields) {
+            if (name.equals(field.name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasMethod(ClassNode classNode, String name, String descriptor) {
+        for (MethodNode method : classNode.methods) {
+            if (name.equals(method.name) && descriptor.equals(method.desc)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/folia-phantom/folia-phantom-core/src/test/java/com/patch/foliaphantom/transformer/SchedulerClassTransformerTest.java
+++ b/folia-phantom/folia-phantom-core/src/test/java/com/patch/foliaphantom/transformer/SchedulerClassTransformerTest.java
@@ -1,0 +1,192 @@
+package com.patch.foliaphantom.transformer;
+
+import org.junit.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.FieldNode;
+import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.VarInsnNode;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class SchedulerClassTransformerTest implements Opcodes {
+
+    private static final String BUKKIT_RUNNABLE = "org/bukkit/scheduler/BukkitRunnable";
+    private static final String BUKKIT_TASK = "org/bukkit/scheduler/BukkitTask";
+    private static final String PATCHER = "com/patch/foliaphantom/patcher/FoliaPatcher";
+    private static final String TEST_CLASS = "example/EcoRunnableTaskLike";
+    private static final String TASK_FIELD = "__pastaBukkitTask";
+
+    private static final String[][] RUNNABLE_METHODS = {
+        {"runTask", "(Lorg/bukkit/plugin/Plugin;)Lorg/bukkit/scheduler/BukkitTask;"},
+        {"runTaskLater", "(Lorg/bukkit/plugin/Plugin;J)Lorg/bukkit/scheduler/BukkitTask;"},
+        {"runTaskTimer", "(Lorg/bukkit/plugin/Plugin;JJ)Lorg/bukkit/scheduler/BukkitTask;"},
+        {"runTaskAsynchronously", "(Lorg/bukkit/plugin/Plugin;)Lorg/bukkit/scheduler/BukkitTask;"},
+        {"runTaskLaterAsynchronously", "(Lorg/bukkit/plugin/Plugin;J)Lorg/bukkit/scheduler/BukkitTask;"},
+        {"runTaskTimerAsynchronously", "(Lorg/bukkit/plugin/Plugin;JJ)Lorg/bukkit/scheduler/BukkitTask;"}
+    };
+
+    @Test
+    public void rewritesAllBukkitRunnableSuperSchedulingCalls() {
+        for (String[] methodSpec : RUNNABLE_METHODS) {
+            String methodName = methodSpec[0];
+            String descriptor = methodSpec[1];
+
+            ClassNode transformed = transform(classWithSchedulingCall(
+                    INVOKESPECIAL, BUKKIT_RUNNABLE, methodName, descriptor));
+            MethodNode callMethod = findMethod(transformed, "call", "()Lorg/bukkit/scheduler/BukkitTask;");
+            MethodInsnNode rewrittenCall = findMethodCall(callMethod, methodName + "_onRunnable");
+
+            assertNotNull("Expected rewritten call for " + methodName, rewrittenCall);
+            assertEquals(INVOKESTATIC, rewrittenCall.getOpcode());
+            assertEquals(PATCHER, rewrittenCall.owner);
+            assertEquals(
+                    "(Ljava/lang/Runnable;" + descriptor.substring(1),
+                    rewrittenCall.desc);
+            assertFalse(rewrittenCall.itf);
+
+            assertTrue("Expected transformed task to be stored for " + methodName,
+                    containsTaskStore(callMethod, transformed.name));
+            assertTrue(hasField(transformed, TASK_FIELD, "L" + BUKKIT_TASK + ";"));
+            assertNotNull(findMethod(transformed, "cancel", "()V"));
+            assertNotNull(findMethod(transformed, "isCancelled", "()Z"));
+            assertNotNull(findMethod(transformed, "getTaskId", "()I"));
+        }
+    }
+
+    @Test
+    public void doesNotRewriteUnrelatedInvokeSpecialWithSameSignature() {
+        String descriptor = "(Lorg/bukkit/plugin/Plugin;JJ)Lorg/bukkit/scheduler/BukkitTask;";
+        ClassNode transformed = transform(classWithSchedulingCall(
+                INVOKESPECIAL, "example/Unrelated", "runTaskTimer", descriptor));
+        MethodNode callMethod = findMethod(transformed, "call", "()Lorg/bukkit/scheduler/BukkitTask;");
+        MethodInsnNode call = findOnlyMethodCall(callMethod);
+
+        assertEquals(INVOKESPECIAL, call.getOpcode());
+        assertEquals("example/Unrelated", call.owner);
+        assertEquals("runTaskTimer", call.name);
+        assertEquals(descriptor, call.desc);
+        assertFalse(hasField(transformed, TASK_FIELD, "L" + BUKKIT_TASK + ";"));
+    }
+
+    @Test
+    public void keepsSubclassInvokeVirtualSupportWithoutInjectingStateIntoCaller() {
+        String descriptor = "(Lorg/bukkit/plugin/Plugin;JJ)Lorg/bukkit/scheduler/BukkitTask;";
+        ClassNode transformed = transform(classWithSchedulingCall(
+                INVOKEVIRTUAL,
+                "com/willfp/eco/internal/scheduling/EcoRunnableTask",
+                "runTaskTimer",
+                descriptor));
+        MethodNode callMethod = findMethod(transformed, "call", "()Lorg/bukkit/scheduler/BukkitTask;");
+        MethodInsnNode call = findMethodCall(callMethod, "runTaskTimer_onRunnable");
+
+        assertNotNull(call);
+        assertEquals(INVOKESTATIC, call.getOpcode());
+        assertEquals(PATCHER, call.owner);
+        assertFalse(hasField(transformed, TASK_FIELD, "L" + BUKKIT_TASK + ";"));
+    }
+
+    private static ClassNode transform(ClassNode input) {
+        SchedulerClassTransformer transformer = new SchedulerClassTransformer();
+        ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+        byte[] bytes = transformer.transform(input, input.name, writer);
+        ClassNode output = new ClassNode(ASM9);
+        new ClassReader(bytes).accept(output, 0);
+        return output;
+    }
+
+    private static ClassNode classWithSchedulingCall(
+            int opcode, String owner, String methodName, String descriptor) {
+        ClassNode classNode = new ClassNode(ASM9);
+        classNode.version = V17;
+        classNode.access = ACC_PUBLIC | ACC_ABSTRACT;
+        classNode.name = TEST_CLASS;
+        classNode.superName = BUKKIT_RUNNABLE;
+
+        MethodNode method = new MethodNode(
+                ASM9,
+                ACC_PUBLIC,
+                "call",
+                "()Lorg/bukkit/scheduler/BukkitTask;",
+                null,
+                null);
+        method.instructions.add(new VarInsnNode(ALOAD, 0));
+        for (Type argumentType : Type.getArgumentTypes(descriptor)) {
+            switch (argumentType.getSort()) {
+                case Type.LONG -> method.instructions.add(new InsnNode(LCONST_0));
+                case Type.FLOAT -> method.instructions.add(new InsnNode(FCONST_0));
+                case Type.DOUBLE -> method.instructions.add(new InsnNode(DCONST_0));
+                case Type.BOOLEAN, Type.BYTE, Type.CHAR, Type.SHORT, Type.INT ->
+                        method.instructions.add(new InsnNode(ICONST_0));
+                default -> method.instructions.add(new InsnNode(ACONST_NULL));
+            }
+        }
+        method.instructions.add(new MethodInsnNode(
+                opcode, owner, methodName, descriptor, false));
+        method.instructions.add(new InsnNode(ARETURN));
+        classNode.methods.add(method);
+        return classNode;
+    }
+
+    private static MethodNode findMethod(ClassNode classNode, String name, String descriptor) {
+        for (MethodNode method : classNode.methods) {
+            if (name.equals(method.name) && descriptor.equals(method.desc)) {
+                return method;
+            }
+        }
+        return null;
+    }
+
+    private static MethodInsnNode findMethodCall(MethodNode method, String name) {
+        if (method == null) {
+            return null;
+        }
+        for (AbstractInsnNode instruction : method.instructions) {
+            if (instruction instanceof MethodInsnNode methodInsn && name.equals(methodInsn.name)) {
+                return methodInsn;
+            }
+        }
+        return null;
+    }
+
+    private static MethodInsnNode findOnlyMethodCall(MethodNode method) {
+        MethodInsnNode result = null;
+        for (AbstractInsnNode instruction : method.instructions) {
+            if (instruction instanceof MethodInsnNode methodInsn) {
+                result = methodInsn;
+            }
+        }
+        return result;
+    }
+
+    private static boolean containsTaskStore(MethodNode method, String owner) {
+        for (AbstractInsnNode instruction : method.instructions) {
+            if (instruction instanceof FieldInsnNode fieldInsn
+                    && fieldInsn.getOpcode() == PUTFIELD
+                    && owner.equals(fieldInsn.owner)
+                    && TASK_FIELD.equals(fieldInsn.name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasField(ClassNode classNode, String name, String descriptor) {
+        for (FieldNode field : classNode.fields) {
+            if (name.equals(field.name) && descriptor.equals(field.desc)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Problem

Fixes #46.

eco 6.77.4 implements `EcoRunnableTask.runTask*()` by calling `super.runTask*(plugin, ...)`. Those calls compile to `INVOKESPECIAL org/bukkit/scheduler/BukkitRunnable`, while pasta's scheduler transformer only rewrote `INVOKEVIRTUAL` BukkitRunnable calls. The call therefore survived patching and reached Folia/Luminol's legacy `CraftScheduler`, producing `UnsupportedOperationException`.

## Change

- rewrite exact-owner `INVOKESPECIAL BukkitRunnable.runTask*` calls to the existing `FoliaPatcher.*_onRunnable` bridge
- retain the existing descriptor guard and only accept `INVOKESPECIAL` when the owner is exactly `BukkitRunnable`
- preserve task state for super-call wrappers in a synthetic `BukkitTask` field
- inject `cancel()`, `isCancelled()`, and `getTaskId()` overrides that operate on the Folia-backed `BukkitTask`, avoiding a return to the legacy Bukkit scheduler
- add regression coverage for all six BukkitRunnable scheduling variants, unrelated `INVOKESPECIAL` calls, and the existing subclass `INVOKEVIRTUAL` path

## Why state preservation is needed

Paper's `BukkitRunnable.cancel()` calls `Bukkit.getScheduler().cancelTask(getTaskId())`. Simply rewriting the scheduling call would make eco start correctly but could still fail when libreforge calls `task.cancel()`. The injected overrides keep those operations on the Folia-backed task returned by pasta.

## Verification

- source behavior checked against eco `6.77.4` `EcoRunnableTask`
- failure path matched against Issue #46 stack trace (`EcoRunnableTask.runTaskTimer` -> `BukkitRunnable.runTaskTimer` -> `CraftScheduler`)
- automated transformer regression tests added
- CI pending

## Risk

The new state field/overrides are injected only into classes where an exact `BukkitRunnable` super scheduling call is transformed. Normal subclass `INVOKEVIRTUAL` rewriting remains unchanged.